### PR TITLE
Handle unmirrored submodules and unprivileged setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     clang \
     make \
+    sudo \
     && rm -rf /var/lib/apt/lists/*
 
 # Claude Code refuses --dangerously-skip-permissions as root.
-RUN useradd -m -s /bin/bash agent
+RUN useradd -m -s /bin/bash agent \
+    && echo "agent ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/agent
 USER agent
 
 # Language toolchains are installed by AGENT_SETUP, not here.

--- a/test.sh
+++ b/test.sh
@@ -61,8 +61,17 @@ git push origin agent-work
 - Use the exact bash commands above. Do not improvise.
 PROMPT
 
+# Write a setup script that requires root (tests sudo in harness).
+SETUP_FILE=".claude-swarm-smoke-setup.sh"
+cat > "$REPO_ROOT/$SETUP_FILE" <<'SETUP'
+#!/bin/bash
+set -euo pipefail
+apt-get update -qq > /dev/null
+echo "Smoke test setup complete."
+SETUP
+
 cd "$REPO_ROOT"
-git add -f "$PROMPT_FILE"
+git add -f "$PROMPT_FILE" "$SETUP_FILE"
 git commit --quiet -m "tmp: smoke test prompt"
 PROMPT_COMMITTED=true
 
@@ -70,6 +79,7 @@ cleanup() {
     echo ""
     echo "--- Cleaning up ---"
     AGENT_PROMPT="$PROMPT_FILE" \
+        AGENT_SETUP="$SETUP_FILE" \
         ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY}" \
         NUM_AGENTS="${NUM_AGENTS}" \
         "$SWARM_DIR/launch.sh" stop 2>/dev/null || true
@@ -87,6 +97,7 @@ echo "=== Smoke test: ${NUM_AGENTS} agents ==="
 echo ""
 
 AGENT_PROMPT="$PROMPT_FILE" \
+    AGENT_SETUP="$SETUP_FILE" \
     ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY}" \
     NUM_AGENTS="${NUM_AGENTS}" \
     "$SWARM_DIR/launch.sh" start


### PR DESCRIPTION
launch.sh uses `git submodule foreach` to create mirrors, which
only iterates initialized submodules. When client submodules are
lazy (not initialized on the host), no mirrors are created. The
old harness rewrote all submodule URLs to /mirrors/ and ran
--init --recursive, fataling on every unmirored path.

Now the harness checks whether each mirror directory exists before
rewriting the URL and initializing. Submodules without mirrors
keep their upstream URLs for agents to clone on demand.

The setup script (AGENT_SETUP) runs as the non-root agent user,
but typically needs root for apt-get. Add sudo to the image and
run setup via `sudo bash` so project-specific scripts work
without modification.

Update the smoke test to exercise the setup path by including a
small script that runs apt-get update (requires root).