### PR TITLE
Fix harvest.sh silent abort when >20 new commits

### DIFF
--- a/harvest.sh
+++ b/harvest.sh
@@ -29,10 +29,11 @@ echo "--- Fetching agent-work ---"
 git remote add "$REMOTE_NAME" "$BARE_REPO"
 git fetch "$REMOTE_NAME" agent-work
 
-NEW_COMMITS=$(git log --oneline "$REMOTE_NAME/agent-work" ^HEAD | wc -l)
+COMMIT_LOG=$(git log --oneline "$REMOTE_NAME/agent-work" ^HEAD)
+NEW_COMMITS=$(echo "$COMMIT_LOG" | grep -c . || true)
 echo ""
 echo "${NEW_COMMITS} new commits on agent-work:"
-git log --oneline "$REMOTE_NAME/agent-work" ^HEAD | head -20
+echo "$COMMIT_LOG" | head -20
 if [ "$NEW_COMMITS" -gt 20 ]; then
     echo "  ... and $((NEW_COMMITS - 20)) more"
 fi


### PR DESCRIPTION
git log | head -20 triggers SIGPIPE when the log has more than
20 lines, since head closes the pipe early. With set -eo pipefail
the non-zero pipeline status aborts the script before the merge.

Capture the log into a variable first, then truncate with
echo | head which avoids the broken pipe.