### PR TITLE
Fix harness crash when repo has no submodules

### DIFF
--- a/harness.sh
+++ b/harness.sh
@@ -24,15 +24,17 @@ if [ ! -d "/workspace/.git" ]; then
     # Init only submodules whose mirrors were mounted into the
     # container. Client submodules without mirrors keep their
     # upstream URLs and are left for the agent to init on demand.
-    git config --file .gitmodules --get-regexp 'submodule\..*\.path' | \
-    while read -r key path; do
-        name="${key#submodule.}"
-        name="${name%.path}"
-        if [ -d "/mirrors/${name}" ]; then
-            git config "submodule.${name}.url" "/mirrors/${name}"
-            git submodule update --init -- "$path"
-        fi
-    done
+    if [ -f .gitmodules ]; then
+        git config --file .gitmodules --get-regexp 'submodule\..*\.path' | \
+        while read -r key path; do
+            name="${key#submodule.}"
+            name="${name%.path}"
+            if [ -d "/mirrors/${name}" ]; then
+                git config "submodule.${name}.url" "/mirrors/${name}"
+                git submodule update --init -- "$path"
+            fi
+        done
+    fi
 
     git checkout agent-work
 


### PR DESCRIPTION
git config --file .gitmodules fails with exit 1 when .gitmodules
does not exist, which kills the container under set -euo pipefail.
Guard the submodule remapping block with an existence check.