### PR TITLE
Add per-agent model config, TUI dashboard, and interactive setup

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,29 @@
+# Global Context (Always-on)
+
+Only this layer is always-on. Agents, skills, and references are
+elective.
+
+## Epistemics
+
+- Do not fabricate results, measurements, outputs, behaviors, or claims of
+  execution.
+- Never invent or infer tool results, filesystem state, repository state,
+  commit history, build status, runtime behavior, or system configuration.
+- If required information is missing, unknown, ambiguous, or cannot be
+  verified directly from provided context, state this explicitly and stop.
+- Do not guess, interpolate, “fill in”, or approximate unknown facts.
+- Separate direct observation from inference and label inference explicitly.
+- Prefer real, production code paths over synthetic or hypothetical examples.
+- Treat panics, resource exhaustion, undefined behavior, and crashes as
+  security-relevant until proven otherwise.
+
+## Quality bars (non-procedural)
+
+- Wrap commit bodies, docs, and examples to 79 chars.
+- Prefer one logical change per commit.
+- When possible, use curly braces; avoid one-line conditionals or loops.
+- Avoid vague filler verbs; prefer direct, concrete wording.
+- Comments must end with a dot.
+- Commit subjects: imperative, specific (e.g., "Add fuzz target for X").
+- Commit bodies: explain motivation/impact, not just what changed.
+- Sentences in commit bodies must end with a dot.

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     clang \
     make \
+    jq \
     sudo \
     && rm -rf /var/lib/apt/lists/*
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Or configure manually:
     ./tools/claude-swarm/launch.sh start
     ./tools/claude-swarm/launch.sh status
     ./tools/claude-swarm/launch.sh logs 1
+    ./tools/claude-swarm/launch.sh wait
     ./tools/claude-swarm/launch.sh stop
 
 SWARM_MODEL defaults to claude-opus-4-6.
@@ -119,6 +120,30 @@ When a config file is present it takes precedence over env vars.
 Always-on TUI showing agent status, models, session counts, and
 recent commits. Keyboard shortcuts: `q` quit, `1`-`9` show agent
 logs, `h` harvest, `s` stop all, `p` post-process.
+
+## Post-processing
+
+Add a `post_process` section to `swarm.json`:
+
+```json
+{
+  "post_process": {
+    "prompt": "prompts/review.md",
+    "model": "claude-opus-4-6"
+  }
+}
+```
+
+After all agents finish (or manually):
+
+    ./tools/claude-swarm/launch.sh wait          # blocks until done, then post-processes + harvests
+    ./tools/claude-swarm/launch.sh post-process   # run post-processing immediately
+
+The `wait` command polls until all agents exit, then launches a
+single post-processing agent with a different prompt against the
+same bare repo.  The post-processing agent sees all agent commits
+on `agent-work`, does its review/consolidation, and pushes.
+Results are harvested automatically.
 
 ## Inspect and harvest results
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Or configure manually:
     export ANTHROPIC_API_KEY="sk-ant-..."
     export SWARM_PROMPT="path/to/prompt.md"
     ./tools/claude-swarm/launch.sh start
+    ./tools/claude-swarm/launch.sh start --dashboard
     ./tools/claude-swarm/launch.sh status
     ./tools/claude-swarm/launch.sh logs 1
     ./tools/claude-swarm/launch.sh wait
@@ -154,9 +155,11 @@ Results are harvested automatically.
 ## Smoke test
 
     ANTHROPIC_API_KEY="sk-ant-..." ./tools/claude-swarm/test.sh
+    ANTHROPIC_API_KEY="sk-ant-..." ./tools/claude-swarm/test.sh --config swarm.json
 
-Launches SWARM_NUM_AGENTS (default 2) agents with an embedded counting prompt,
-verifies each agent writes deterministic output and pushes.
+Launches agents with an embedded counting prompt, verifies each agent
+writes deterministic output and pushes.  The `--config` flag runs the
+smoke test with a config file (mixed models, custom endpoints).
 
 ## Verify image
 

--- a/README.md
+++ b/README.md
@@ -15,15 +15,15 @@ Add as a submodule:
 ## Usage
 
     export ANTHROPIC_API_KEY="sk-ant-..."
-    export AGENT_PROMPT="path/to/prompt.md"
+    export SWARM_PROMPT="path/to/prompt.md"
     ./tools/claude-swarm/launch.sh start
     ./tools/claude-swarm/launch.sh status
     ./tools/claude-swarm/launch.sh logs 1
     ./tools/claude-swarm/launch.sh stop
 
-CLAUDE_MODEL defaults to claude-opus-4-6.
-NUM_AGENTS defaults to 3.
-MAX_IDLE defaults to 3 (exit after N consecutive idle sessions).
+SWARM_MODEL defaults to claude-opus-4-6.
+SWARM_NUM_AGENTS defaults to 3.
+SWARM_MAX_IDLE defaults to 3 (exit after N consecutive idle sessions).
 
 ## How it works
 
@@ -62,13 +62,13 @@ Agents stop after MAX_IDLE consecutive sessions with no commits.
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | ANTHROPIC_API_KEY | yes | | API key. |
-| AGENT_PROMPT | yes | | Path to prompt file (relative to repo root). |
-| AGENT_SETUP | no | | Path to setup script (relative to repo root). |
-| CLAUDE_MODEL | no | claude-opus-4-6 | Model for Claude Code. |
-| NUM_AGENTS | no | 3 | Number of containers. |
-| MAX_IDLE | no | 3 | Idle sessions before exit. |
-| GIT_USER_NAME | no | swarm-agent | Git author name for agent commits. |
-| GIT_USER_EMAIL | no | agent@claude-swarm.local | Git author email for agent commits. |
+| SWARM_PROMPT | yes | | Path to prompt file (relative to repo root). |
+| SWARM_SETUP | no | | Path to setup script (relative to repo root). |
+| SWARM_MODEL | no | claude-opus-4-6 | Model for Claude Code. |
+| SWARM_NUM_AGENTS | no | 3 | Number of containers. |
+| SWARM_MAX_IDLE | no | 3 | Idle sessions before exit. |
+| SWARM_GIT_USER_NAME | no | swarm-agent | Git author name for agent commits. |
+| SWARM_GIT_USER_EMAIL | no | agent@claude-swarm.local | Git author email for agent commits. |
 | ANTHROPIC_BASE_URL | no | | Override API URL (e.g. OpenRouter). |
 | ANTHROPIC_AUTH_TOKEN | no | | Override auth token. |
 
@@ -82,7 +82,7 @@ Agents stop after MAX_IDLE consecutive sessions with no commits.
 
     ANTHROPIC_API_KEY="sk-ant-..." ./tools/claude-swarm/test.sh
 
-Launches NUM_AGENTS (default 2) with an embedded counting prompt,
+Launches SWARM_NUM_AGENTS (default 2) agents with an embedded counting prompt,
 verifies each agent writes deterministic output and pushes.
 
 ## Verify image

--- a/README.md
+++ b/README.md
@@ -106,6 +106,14 @@ Requires `jq` on the host.
 
 When a config file is present it takes precedence over env vars.
 
+## Dashboard
+
+    ./tools/claude-swarm/dashboard.sh
+
+Always-on TUI showing agent status, models, session counts, and
+recent commits. Keyboard shortcuts: `q` quit, `1`-`9` show agent
+logs, `h` harvest, `s` stop all, `p` post-process.
+
 ## Inspect and harvest results
 
     ./tools/claude-swarm/progress.sh

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ Add as a submodule:
 
 ## Usage
 
+Interactive setup (produces `swarm.json`):
+
+    ./tools/claude-swarm/setup.sh
+
+Or configure manually:
+
     export ANTHROPIC_API_KEY="sk-ant-..."
     export SWARM_PROMPT="path/to/prompt.md"
     ./tools/claude-swarm/launch.sh start

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,0 +1,115 @@
+# Usage
+
+## Quick start
+
+```bash
+# Interactive setup (generates swarm.json).
+./tools/claude-swarm/setup.sh
+
+# Or configure via environment.
+export ANTHROPIC_API_KEY="sk-ant-..."
+export SWARM_PROMPT="path/to/prompt.md"
+./tools/claude-swarm/launch.sh start
+```
+
+## Commands
+
+```bash
+./launch.sh start              # Launch agents.
+./launch.sh start --dashboard  # Launch agents and open TUI.
+./launch.sh stop               # Stop all agents.
+./launch.sh status             # Show running containers.
+./launch.sh logs N             # Tail logs for agent N.
+./launch.sh wait               # Block until done, harvest,
+                               # and post-process if configured.
+./launch.sh post-process       # Run post-processing agent.
+```
+
+## Dashboard
+
+```bash
+./dashboard.sh                 # Attach to TUI dashboard.
+```
+
+Shows agent status, models, session counts, and recent
+commits (with model attribution).
+
+Keyboard shortcuts:
+
+| Key   | Action              |
+|-------|---------------------|
+| `q`   | Quit dashboard.     |
+| `l N` | Logs for agent N.   |
+| `h`   | Harvest results.    |
+| `s`   | Stop all agents.    |
+| `p`   | Post-process.       |
+
+Re-run `./dashboard.sh` to re-attach while agents run.
+
+## Testing
+
+Basic smoke test:
+
+```bash
+ANTHROPIC_API_KEY="sk-..." ./test.sh
+```
+
+With a specific model:
+
+```bash
+ANTHROPIC_API_KEY="sk-..." SWARM_MODEL="claude-sonnet-4-6" \
+    ./test.sh
+```
+
+With a config file (mixed models):
+
+```bash
+ANTHROPIC_API_KEY="sk-..." ./test.sh --config swarm.json
+```
+
+`test.sh` always uses its own built-in prompt regardless of
+what the config file specifies.
+
+Config parsing unit tests (no Docker or API key needed):
+
+```bash
+./test_config.sh
+```
+
+## Post-processing
+
+Add a `post_process` section to `swarm.json`:
+
+```json
+{
+  "post_process": {
+    "prompt": "prompts/review.md",
+    "model": "claude-opus-4-6"
+  }
+}
+```
+
+Trigger via `[p]` in the dashboard, `./launch.sh post-process`,
+or automatically through `./launch.sh wait`.
+
+The post-process agent clones the same bare repo, sees all
+agent commits on `agent-work`, runs its prompt, and pushes.
+
+## Cleanup
+
+Remove the bare repo after testing:
+
+```bash
+rm -rf /tmp/<project>-upstream.git
+```
+
+## Verify image
+
+```bash
+docker run --rm --entrypoint bash \
+    -e "ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY" \
+    $(basename $(pwd))-agent \
+    -c 'claude --dangerously-skip-permissions \
+        -p "What model are you? Reply with model id only." \
+        --model claude-opus-4-6 2>&1'
+```

--- a/dashboard.sh
+++ b/dashboard.sh
@@ -1,0 +1,228 @@
+#!/bin/bash
+set -euo pipefail
+
+# Always-on TUI dashboard for claude-swarm.
+# Pure bash with ANSI escape codes and tput.
+
+SWARM_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+PROJECT="$(basename "$REPO_ROOT")"
+BARE_REPO="/tmp/${PROJECT}-upstream.git"
+IMAGE_NAME="${PROJECT}-agent"
+START_TIME=$(date +%s)
+
+CONFIG_FILE="${SWARM_CONFIG:-}"
+if [ -z "$CONFIG_FILE" ] && [ -f "$REPO_ROOT/swarm.json" ]; then
+    CONFIG_FILE="$REPO_ROOT/swarm.json"
+fi
+
+if [ -n "$CONFIG_FILE" ]; then
+    AGENT_PROMPT=$(jq -r '.prompt // empty' "$CONFIG_FILE")
+    NUM_AGENTS=$(jq '[.agents[].count] | add' "$CONFIG_FILE")
+    MODEL_SUMMARY=$(jq -r \
+        '[.agents[] | "\(.count)x \(.model | split("/") | .[-1])"] | join(", ")' \
+        "$CONFIG_FILE")
+    CONFIG_LABEL="$(basename "$CONFIG_FILE")"
+else
+    NUM_AGENTS="${SWARM_NUM_AGENTS:-3}"
+    AGENT_PROMPT="${SWARM_PROMPT:-}"
+    CLAUDE_MODEL="${SWARM_MODEL:-claude-opus-4-6}"
+    MODEL_SUMMARY="${NUM_AGENTS}x ${CLAUDE_MODEL}"
+    CONFIG_LABEL="env vars"
+fi
+
+BOLD=$'\033[1m'
+DIM=$'\033[2m'
+GREEN=$'\033[32m'
+YELLOW=$'\033[33m'
+RED=$'\033[31m'
+RESET=$'\033[0m'
+
+TERM_COLS=80
+
+handle_resize() {
+    TERM_COLS=$(tput cols 2>/dev/null || echo 80)
+}
+trap handle_resize SIGWINCH
+handle_resize
+
+cleanup() {
+    tput rmcup 2>/dev/null || true
+    tput cnorm 2>/dev/null || true
+}
+trap cleanup EXIT
+
+enter_alt_screen() {
+    tput smcup 2>/dev/null || true
+    tput civis 2>/dev/null || true
+}
+
+leave_alt_screen() {
+    tput rmcup 2>/dev/null || true
+    tput cnorm 2>/dev/null || true
+}
+
+format_duration() {
+    local s=$1
+    if [ "$s" -ge 3600 ]; then
+        printf '%dh %02dm' $((s / 3600)) $(((s % 3600) / 60))
+    elif [ "$s" -ge 60 ]; then
+        printf '%dm %02ds' $((s / 60)) $((s % 60))
+    else
+        printf '%ds' "$s"
+    fi
+}
+
+draw() {
+    local now elapsed uptime_str
+    now=$(date +%s)
+    elapsed=$((now - START_TIME))
+    uptime_str=$(format_duration "$elapsed")
+
+    tput cup 0 0
+    tput ed
+
+    # Header.
+    local title=" ${BOLD}claude-swarm${RESET}"
+    local right="${DIM}uptime: ${uptime_str}${RESET}"
+    printf "%b%*s%b\n" "$title" $((TERM_COLS - 13 - ${#uptime_str} - 10)) "" "$right"
+    printf " ${DIM}config: %s | prompt: %s${RESET}\n" "$CONFIG_LABEL" "$AGENT_PROMPT"
+    printf " ${DIM}agents: %s (%s)${RESET}\n" "$NUM_AGENTS" "$MODEL_SUMMARY"
+    echo ""
+
+    # Agent table header.
+    printf "  ${BOLD}%-4s %-20s %-14s %8s${RESET}\n" "#" "Model" "Status" "Sessions"
+
+    local running_count=0 exited_count=0
+
+    for i in $(seq 1 "$NUM_AGENTS"); do
+        local name="${IMAGE_NAME}-${i}"
+
+        local state
+        state=$(docker inspect -f '{{.State.Status}}' "$name" 2>/dev/null || echo "not found")
+
+        local model="unknown"
+        if [ "$state" != "not found" ]; then
+            model=$(docker inspect -f '{{range .Config.Env}}{{println .}}{{end}}' \
+                "$name" 2>/dev/null | grep '^CLAUDE_MODEL=' | head -1 | cut -d= -f2- || true)
+            model="${model:-unknown}"
+        fi
+        local short="${model/claude-/}"
+
+        local sessions=0 idle_str=""
+        if [ "$state" != "not found" ]; then
+            local logs
+            logs=$(docker logs "$name" 2>&1 || true)
+            sessions=$(printf '%s' "$logs" | grep -c "Starting session" || true)
+            idle_str=$(printf '%s' "$logs" | grep -o 'idle [0-9]*/[0-9]*' | tail -1 || true)
+        fi
+
+        local status_text status_color
+        case "$state" in
+            running)
+                running_count=$((running_count + 1))
+                if [ -n "$idle_str" ]; then
+                    status_text="$idle_str"
+                    status_color="$YELLOW"
+                else
+                    status_text="running"
+                    status_color="$GREEN"
+                fi
+                ;;
+            exited)
+                exited_count=$((exited_count + 1))
+                status_text="exited"
+                status_color="$RED"
+                ;;
+            *)
+                status_text="$state"
+                status_color="$DIM"
+                ;;
+        esac
+
+        printf "  %-4s %-20s " "$i" "$short"
+        printf "%b%-14s%b" "$status_color" "$status_text" "$RESET"
+        printf " %7s\n" "$sessions"
+    done
+
+    echo ""
+
+    # Recent commits.
+    if [ -d "$BARE_REPO" ]; then
+        local commit_count
+        commit_count=$(git -C "$BARE_REPO" rev-list --count refs/heads/agent-work 2>/dev/null || echo 0)
+        printf " ${BOLD}Recent commits${RESET} ${DIM}(%s total):${RESET}\n" "$commit_count"
+        git -C "$BARE_REPO" log refs/heads/agent-work --oneline -8 2>/dev/null | \
+        while IFS= read -r line; do
+            printf "   ${DIM}%s${RESET}\n" "$line"
+        done
+    else
+        printf " ${DIM}(bare repo not found -- are agents running?)${RESET}\n"
+    fi
+
+    echo ""
+
+    if [ "$running_count" -eq 0 ] && [ "$exited_count" -gt 0 ]; then
+        printf " ${BOLD}${GREEN}Swarm complete${RESET} -- all %s agents exited.\n" "$exited_count"
+        echo ""
+    fi
+
+    # Help bar.
+    printf " ${DIM}[q]${RESET} quit"
+    printf "  ${DIM}[1-9]${RESET} logs"
+    printf "  ${DIM}[h]${RESET} harvest"
+    printf "  ${DIM}[s]${RESET} stop all"
+    printf "  ${DIM}[p]${RESET} post-process"
+    printf "\n"
+}
+
+enter_alt_screen
+
+while true; do
+    draw
+
+    if read -rsn1 -t 3 key 2>/dev/null; then
+        case "$key" in
+            q|Q)
+                exit 0
+                ;;
+            [1-9])
+                leave_alt_screen
+                echo "--- Logs for ${IMAGE_NAME}-${key} (Ctrl-C to return) ---"
+                docker logs -f "${IMAGE_NAME}-${key}" 2>&1 || true
+                enter_alt_screen
+                ;;
+            h|H)
+                leave_alt_screen
+                "$SWARM_DIR/harvest.sh" || true
+                echo ""
+                read -rp "Press Enter to return to dashboard..." _
+                enter_alt_screen
+                ;;
+            s|S)
+                leave_alt_screen
+                echo "--- Stopping all agents ---"
+                for i in $(seq 1 "$NUM_AGENTS"); do
+                    docker stop "${IMAGE_NAME}-${i}" 2>/dev/null \
+                        && echo "  stopped ${IMAGE_NAME}-${i}" || true
+                done
+                echo ""
+                read -rp "Press Enter to return to dashboard..." _
+                enter_alt_screen
+                ;;
+            p|P)
+                leave_alt_screen
+                echo "--- Stopping agents ---"
+                for i in $(seq 1 "$NUM_AGENTS"); do
+                    docker stop "${IMAGE_NAME}-${i}" 2>/dev/null || true
+                done
+                echo "--- Starting post-processing ---"
+                "$SWARM_DIR/launch.sh" post-process || \
+                    echo "(post-processing not configured -- add post_process to swarm.json)"
+                echo ""
+                read -rp "Press Enter to return to dashboard..." _
+                enter_alt_screen
+                ;;
+        esac
+    fi
+done

--- a/launch.sh
+++ b/launch.sh
@@ -331,7 +331,12 @@ cmd_post_process() {
 }
 
 case "${1:-start}" in
-    start)         cmd_start ;;
+    start)
+        cmd_start
+        if [ "${2:-}" = "--dashboard" ]; then
+            exec "$SWARM_DIR/dashboard.sh"
+        fi
+        ;;
     stop)          cmd_stop ;;
     logs)          cmd_logs "${2:-1}" ;;
     status)        cmd_status ;;

--- a/launch.sh
+++ b/launch.sh
@@ -132,6 +132,11 @@ cmd_start() {
         NAME="${IMAGE_NAME}-${AGENT_IDX}"
         docker rm -f "$NAME" 2>/dev/null || true
 
+        # Tag git user name with model so commits identify the model.
+        local short_model="${agent_model/claude-/}"
+        short_model="${short_model//\//-}"
+        local agent_git_name="${GIT_USER_NAME} [${short_model}]"
+
         echo "--- Launching ${NAME} (${agent_model}) ---"
         EXTRA_ENV=()
         if [ -n "$agent_base_url" ]; then
@@ -152,7 +157,7 @@ cmd_start() {
             -e "AGENT_PROMPT=${AGENT_PROMPT}" \
             -e "AGENT_SETUP=${AGENT_SETUP}" \
             -e "MAX_IDLE=${MAX_IDLE}" \
-            -e "GIT_USER_NAME=${GIT_USER_NAME}" \
+            -e "GIT_USER_NAME=${agent_git_name}" \
             -e "GIT_USER_EMAIL=${GIT_USER_EMAIL}" \
             -e "AGENT_ID=${AGENT_IDX}" \
             "$IMAGE_NAME"

--- a/launch.sh
+++ b/launch.sh
@@ -9,8 +9,13 @@ SWARM_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT="$(basename "$REPO_ROOT")"
 BARE_REPO="/tmp/${PROJECT}-upstream.git"
 IMAGE_NAME="${PROJECT}-agent"
-NUM_AGENTS="${NUM_AGENTS:-3}"
-CLAUDE_MODEL="${CLAUDE_MODEL:-claude-opus-4-6}"
+NUM_AGENTS="${SWARM_NUM_AGENTS:-3}"
+CLAUDE_MODEL="${SWARM_MODEL:-claude-opus-4-6}"
+AGENT_PROMPT="${SWARM_PROMPT:-}"
+AGENT_SETUP="${SWARM_SETUP:-}"
+MAX_IDLE="${SWARM_MAX_IDLE:-3}"
+GIT_USER_NAME="${SWARM_GIT_USER_NAME:-swarm-agent}"
+GIT_USER_EMAIL="${SWARM_GIT_USER_EMAIL:-agent@claude-swarm.local}"
 
 cmd_start() {
     if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
@@ -23,8 +28,8 @@ cmd_start() {
         exit 1
     fi
 
-    if [ -z "${AGENT_PROMPT:-}" ]; then
-        echo "ERROR: AGENT_PROMPT is not set." >&2
+    if [ -z "$AGENT_PROMPT" ]; then
+        echo "ERROR: SWARM_PROMPT is not set." >&2
         exit 1
     fi
 
@@ -101,10 +106,10 @@ cmd_start() {
             "${EXTRA_ENV[@]+"${EXTRA_ENV[@]}"}" \
             -e "CLAUDE_MODEL=${CLAUDE_MODEL}" \
             -e "AGENT_PROMPT=${AGENT_PROMPT}" \
-            -e "AGENT_SETUP=${AGENT_SETUP:-}" \
-            -e "MAX_IDLE=${MAX_IDLE:-3}" \
-            -e "GIT_USER_NAME=${GIT_USER_NAME:-swarm-agent}" \
-            -e "GIT_USER_EMAIL=${GIT_USER_EMAIL:-agent@claude-swarm.local}" \
+            -e "AGENT_SETUP=${AGENT_SETUP}" \
+            -e "MAX_IDLE=${MAX_IDLE}" \
+            -e "GIT_USER_NAME=${GIT_USER_NAME}" \
+            -e "GIT_USER_EMAIL=${GIT_USER_EMAIL}" \
             -e "AGENT_ID=${i}" \
             "$IMAGE_NAME"
     done

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,202 @@
+#!/bin/bash
+set -euo pipefail
+
+# Interactive setup wizard for claude-swarm.
+# Produces a swarm.json config file.
+# Uses whiptail for dialogs; falls back to read-based prompts.
+
+SWARM_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+OUTPUT="$REPO_ROOT/swarm.json"
+USE_WHIPTAIL=false
+
+if command -v whiptail &>/dev/null; then
+    USE_WHIPTAIL=true
+fi
+
+# ---- Dialog helpers ----
+
+msg() {
+    if $USE_WHIPTAIL; then
+        whiptail --title "claude-swarm" --msgbox "$1" 10 60
+    else
+        echo ""
+        echo "$1"
+        echo ""
+    fi
+}
+
+input() {
+    local title="$1" default="$2"
+    if $USE_WHIPTAIL; then
+        whiptail --title "claude-swarm" --inputbox "$title" 10 60 "$default" 3>&1 1>&2 2>&3 || echo "$default"
+    else
+        local val
+        read -rp "$title [$default]: " val
+        echo "${val:-$default}"
+    fi
+}
+
+password() {
+    local title="$1"
+    if $USE_WHIPTAIL; then
+        whiptail --title "claude-swarm" --passwordbox "$title" 10 60 3>&1 1>&2 2>&3 || echo ""
+    else
+        local val
+        read -rsp "$title: " val
+        echo ""
+        echo "$val"
+    fi
+}
+
+yesno() {
+    local title="$1"
+    if $USE_WHIPTAIL; then
+        whiptail --title "claude-swarm" --yesno "$title" 10 60 && return 0 || return 1
+    else
+        local val
+        read -rp "$title [Y/n]: " val
+        case "$val" in
+            [Nn]*) return 1 ;;
+            *)     return 0 ;;
+        esac
+    fi
+}
+
+# ---- Gather settings ----
+
+echo "claude-swarm setup wizard"
+echo "========================="
+echo ""
+
+# 1. API key.
+API_KEY="${ANTHROPIC_API_KEY:-}"
+if [ -n "$API_KEY" ]; then
+    echo "ANTHROPIC_API_KEY detected in environment (${#API_KEY} chars)."
+else
+    API_KEY=$(password "Enter your ANTHROPIC_API_KEY")
+    if [ -z "$API_KEY" ]; then
+        echo "ERROR: API key is required." >&2
+        exit 1
+    fi
+    echo ""
+    echo "Tip: export ANTHROPIC_API_KEY before running launch.sh."
+fi
+
+# 2. Prompt file.
+PROMPT_PATH=$(input "Path to prompt file (relative to repo root)" "")
+if [ -z "$PROMPT_PATH" ]; then
+    echo "ERROR: Prompt file is required." >&2
+    exit 1
+fi
+if [ ! -f "$REPO_ROOT/$PROMPT_PATH" ]; then
+    echo "WARNING: ${PROMPT_PATH} not found in repo root."
+    if ! yesno "Continue anyway?"; then
+        exit 1
+    fi
+fi
+
+# 3. Agent groups.
+AGENTS_JSON="[]"
+GROUP_NUM=0
+
+while true; do
+    GROUP_NUM=$((GROUP_NUM + 1))
+    echo ""
+    echo "--- Agent group ${GROUP_NUM} ---"
+
+    MODEL=$(input "Model name" "claude-opus-4-6")
+    COUNT=$(input "Number of agents with this model" "1")
+
+    AGENT_OBJ="{\"count\": ${COUNT}, \"model\": \"${MODEL}\""
+
+    if yesno "Custom endpoint for this group (e.g. OpenRouter)?"; then
+        BASE_URL=$(input "Base URL" "https://openrouter.ai/api/v1")
+        GROUP_KEY=$(password "API key for this endpoint")
+        AGENT_OBJ+=", \"base_url\": \"${BASE_URL}\""
+        if [ -n "$GROUP_KEY" ]; then
+            AGENT_OBJ+=", \"api_key\": \"${GROUP_KEY}\""
+        fi
+    fi
+
+    AGENT_OBJ+="}"
+    AGENTS_JSON=$(echo "$AGENTS_JSON" | jq --argjson obj "$AGENT_OBJ" '. + [$obj]')
+
+    TOTAL=$(echo "$AGENTS_JSON" | jq '[.[].count] | add')
+    echo ""
+    echo "Total agents so far: ${TOTAL}"
+
+    if ! yesno "Add another agent group?"; then
+        break
+    fi
+done
+
+# 4. Advanced settings.
+SETUP_PATH=""
+MAX_IDLE=3
+GIT_NAME="swarm-agent"
+GIT_EMAIL="agent@claude-swarm.local"
+
+if yesno "Configure advanced settings (setup script, idle limit, git user)?"; then
+    SETUP_PATH=$(input "Setup script path (blank to skip)" "")
+    MAX_IDLE=$(input "Max idle sessions before exit" "3")
+    GIT_NAME=$(input "Git user name for agent commits" "swarm-agent")
+    GIT_EMAIL=$(input "Git user email for agent commits" "agent@claude-swarm.local")
+fi
+
+# 5. Post-processing.
+POST_PROMPT=""
+POST_MODEL=""
+
+if yesno "Configure post-processing (runs after all agents finish)?"; then
+    POST_PROMPT=$(input "Post-processing prompt file" "")
+    POST_MODEL=$(input "Model for post-processing" "claude-opus-4-6")
+fi
+
+# ---- Build config ----
+
+CONFIG=$(jq -n \
+    --arg prompt "$PROMPT_PATH" \
+    --arg setup "$SETUP_PATH" \
+    --argjson max_idle "$MAX_IDLE" \
+    --arg git_name "$GIT_NAME" \
+    --arg git_email "$GIT_EMAIL" \
+    --argjson agents "$AGENTS_JSON" \
+    '{
+        prompt: $prompt,
+        max_idle: $max_idle,
+        git_user: { name: $git_name, email: $git_email },
+        agents: $agents
+    }
+    | if $setup != "" then .setup = $setup else . end')
+
+if [ -n "$POST_PROMPT" ]; then
+    CONFIG=$(echo "$CONFIG" | jq \
+        --arg pp_prompt "$POST_PROMPT" \
+        --arg pp_model "$POST_MODEL" \
+        '. + { post_process: { prompt: $pp_prompt, model: $pp_model } }')
+fi
+
+# ---- Review and write ----
+
+echo ""
+echo "=== Generated config ==="
+echo "$CONFIG" | jq .
+echo ""
+
+TOTAL=$(echo "$CONFIG" | jq '[.agents[].count] | add')
+echo "Total agents: ${TOTAL}"
+echo "Output: ${OUTPUT}"
+echo ""
+
+if yesno "Write ${OUTPUT}?"; then
+    echo "$CONFIG" | jq . > "$OUTPUT"
+    echo "Config written to ${OUTPUT}"
+    echo ""
+    if yesno "Launch swarm now?"; then
+        export ANTHROPIC_API_KEY="$API_KEY"
+        "$SWARM_DIR/launch.sh" start
+    fi
+else
+    echo "Aborted."
+fi

--- a/test.sh
+++ b/test.sh
@@ -9,7 +9,7 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 PROJECT="$(basename "$REPO_ROOT")"
 BARE_REPO="/tmp/${PROJECT}-upstream.git"
 REVIEW_DIR="/tmp/${PROJECT}-test-review"
-NUM_AGENTS="${NUM_AGENTS:-2}"
+NUM_AGENTS="${SWARM_NUM_AGENTS:-2}"
 TIMEOUT="${TIMEOUT:-600}"
 
 # Write the smoke test prompt as a temp file and commit it.
@@ -79,10 +79,10 @@ cleanup() {
     echo ""
     echo "--- Cleaning up ---"
     cd "$REPO_ROOT"
-    AGENT_PROMPT="$PROMPT_FILE" \
-        AGENT_SETUP="$SETUP_FILE" \
+    SWARM_PROMPT="$PROMPT_FILE" \
+        SWARM_SETUP="$SETUP_FILE" \
         ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY}" \
-        NUM_AGENTS="${NUM_AGENTS}" \
+        SWARM_NUM_AGENTS="${NUM_AGENTS}" \
         "$SWARM_DIR/launch.sh" stop 2>/dev/null || true
     rm -rf "$REVIEW_DIR"
 
@@ -96,10 +96,10 @@ trap cleanup EXIT
 echo "=== Smoke test: ${NUM_AGENTS} agents ==="
 echo ""
 
-AGENT_PROMPT="$PROMPT_FILE" \
-    AGENT_SETUP="$SETUP_FILE" \
+SWARM_PROMPT="$PROMPT_FILE" \
+    SWARM_SETUP="$SETUP_FILE" \
     ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY}" \
-    NUM_AGENTS="${NUM_AGENTS}" \
+    SWARM_NUM_AGENTS="${NUM_AGENTS}" \
     "$SWARM_DIR/launch.sh" start
 
 echo ""

--- a/test.sh
+++ b/test.sh
@@ -9,8 +9,19 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 PROJECT="$(basename "$REPO_ROOT")"
 BARE_REPO="/tmp/${PROJECT}-upstream.git"
 REVIEW_DIR="/tmp/${PROJECT}-test-review"
-NUM_AGENTS="${SWARM_NUM_AGENTS:-2}"
 TIMEOUT="${TIMEOUT:-600}"
+
+CONFIG_FILE=""
+if [ "${1:-}" = "--config" ] && [ -n "${2:-}" ]; then
+    CONFIG_FILE="$2"
+    if [ ! -f "$CONFIG_FILE" ]; then
+        echo "ERROR: Config file ${CONFIG_FILE} not found." >&2
+        exit 1
+    fi
+    NUM_AGENTS=$(jq '[.agents[].count] | add' "$CONFIG_FILE")
+else
+    NUM_AGENTS="${SWARM_NUM_AGENTS:-2}"
+fi
 
 # Write the smoke test prompt as a temp file and commit it.
 PROMPT_FILE=".claude-swarm-smoke-test.md"
@@ -75,18 +86,31 @@ git add -f "$PROMPT_FILE" "$SETUP_FILE"
 git commit --quiet -m "tmp: smoke test prompt"
 PROMPT_COMMITTED=true
 
+# When using a config file, create a temp copy with prompt/setup overridden.
+TEMP_CONFIG=""
+if [ -n "$CONFIG_FILE" ]; then
+    TEMP_CONFIG=$(mktemp /tmp/${PROJECT}-test-config.XXXXXX.json)
+    jq --arg p "$PROMPT_FILE" --arg s "$SETUP_FILE" \
+        '.prompt = $p | .setup = $s' "$CONFIG_FILE" > "$TEMP_CONFIG"
+fi
+
 cleanup() {
     echo ""
     echo "--- Cleaning up ---"
     cd "$REPO_ROOT"
-    SWARM_PROMPT="$PROMPT_FILE" \
-        SWARM_SETUP="$SETUP_FILE" \
-        ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY}" \
-        SWARM_NUM_AGENTS="${NUM_AGENTS}" \
-        "$SWARM_DIR/launch.sh" stop 2>/dev/null || true
-    rm -rf "$REVIEW_DIR"
+    if [ -n "$TEMP_CONFIG" ]; then
+        SWARM_CONFIG="$TEMP_CONFIG" \
+            "$SWARM_DIR/launch.sh" stop 2>/dev/null || true
+        rm -f "$TEMP_CONFIG"
+    else
+        SWARM_PROMPT="$PROMPT_FILE" \
+            SWARM_SETUP="$SETUP_FILE" \
+            ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY}" \
+            SWARM_NUM_AGENTS="${NUM_AGENTS}" \
+            "$SWARM_DIR/launch.sh" stop 2>/dev/null || true
+    fi
+    rm -rf "$REVIEW_DIR" /tmp/${PROJECT}-upstream.git
 
-    # Undo the temp commit.
     if [ "${PROMPT_COMMITTED:-}" = true ]; then
         git reset --quiet --hard HEAD~1
     fi
@@ -96,11 +120,17 @@ trap cleanup EXIT
 echo "=== Smoke test: ${NUM_AGENTS} agents ==="
 echo ""
 
-SWARM_PROMPT="$PROMPT_FILE" \
-    SWARM_SETUP="$SETUP_FILE" \
-    ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY}" \
-    SWARM_NUM_AGENTS="${NUM_AGENTS}" \
-    "$SWARM_DIR/launch.sh" start
+if [ -n "$TEMP_CONFIG" ]; then
+    SWARM_CONFIG="$TEMP_CONFIG" \
+        ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-}" \
+        "$SWARM_DIR/launch.sh" start
+else
+    SWARM_PROMPT="$PROMPT_FILE" \
+        SWARM_SETUP="$SETUP_FILE" \
+        ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY}" \
+        SWARM_NUM_AGENTS="${NUM_AGENTS}" \
+        "$SWARM_DIR/launch.sh" start
+fi
 
 echo ""
 echo "--- Waiting for agents (timeout ${TIMEOUT}s) ---"

--- a/test_config.sh
+++ b/test_config.sh
@@ -1,0 +1,217 @@
+#!/bin/bash
+set -euo pipefail
+
+# Unit tests for swarm.json config parsing.
+# No Docker or API key required -- validates jq expressions only.
+
+PASS=0
+FAIL=0
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        echo "  PASS: ${label}"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: ${label}"
+        echo "        expected: ${expected}"
+        echo "        actual:   ${actual}"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# --- Helpers: same jq expressions used in launch.sh ---
+
+parse_prompt()     { jq -r '.prompt // empty' "$1"; }
+parse_setup()      { jq -r '.setup // empty' "$1"; }
+parse_max_idle()   { jq -r '.max_idle // 3' "$1"; }
+parse_git_name()   { jq -r '.git_user.name // "swarm-agent"' "$1"; }
+parse_git_email()  { jq -r '.git_user.email // "agent@claude-swarm.local"' "$1"; }
+parse_num_agents() { jq '[.agents[].count] | add' "$1"; }
+
+parse_agents_tsv() {
+    jq -r '.agents[] | range(.count) as $i |
+        [.model, (.base_url // ""), (.api_key // "")] | @tsv' "$1"
+}
+
+# ============================================================
+echo "=== 1. Mixed-model config ==="
+
+cat > "$TMPDIR/mixed.json" <<'EOF'
+{
+  "prompt": "prompts/task.md",
+  "setup": "scripts/setup.sh",
+  "max_idle": 5,
+  "git_user": { "name": "test-agent", "email": "test@example.com" },
+  "agents": [
+    { "count": 2, "model": "claude-opus-4-6" },
+    { "count": 1, "model": "claude-sonnet-4-5" },
+    { "count": 3, "model": "openrouter/custom", "base_url": "https://openrouter.ai/api/v1", "api_key": "sk-or-test" }
+  ]
+}
+EOF
+
+assert_eq "prompt"    "prompts/task.md"  "$(parse_prompt "$TMPDIR/mixed.json")"
+assert_eq "setup"     "scripts/setup.sh" "$(parse_setup "$TMPDIR/mixed.json")"
+assert_eq "max_idle"  "5"                "$(parse_max_idle "$TMPDIR/mixed.json")"
+assert_eq "git name"  "test-agent"       "$(parse_git_name "$TMPDIR/mixed.json")"
+assert_eq "git email" "test@example.com" "$(parse_git_email "$TMPDIR/mixed.json")"
+assert_eq "total agents" "6"             "$(parse_num_agents "$TMPDIR/mixed.json")"
+
+TSV=$(parse_agents_tsv "$TMPDIR/mixed.json")
+assert_eq "line count" "6" "$(echo "$TSV" | wc -l | tr -d ' ')"
+
+LINE1=$(echo "$TSV" | sed -n '1p')
+LINE3=$(echo "$TSV" | sed -n '3p')
+LINE4=$(echo "$TSV" | sed -n '4p')
+LINE6=$(echo "$TSV" | sed -n '6p')
+
+IFS=$'\t' read -r m1 u1 k1 <<< "$LINE1"
+assert_eq "agent 1 model"   "claude-opus-4-6" "$m1"
+assert_eq "agent 1 base_url" ""               "$u1"
+assert_eq "agent 1 api_key"  ""               "$k1"
+
+IFS=$'\t' read -r m3 u3 k3 <<< "$LINE3"
+assert_eq "agent 3 model" "claude-sonnet-4-5" "$m3"
+
+IFS=$'\t' read -r m4 u4 k4 <<< "$LINE4"
+assert_eq "agent 4 model"    "openrouter/custom"                "$m4"
+assert_eq "agent 4 base_url" "https://openrouter.ai/api/v1"     "$u4"
+assert_eq "agent 4 api_key"  "sk-or-test"                       "$k4"
+
+IFS=$'\t' read -r m6 u6 k6 <<< "$LINE6"
+assert_eq "agent 6 model"    "openrouter/custom"                "$m6"
+assert_eq "agent 6 base_url" "https://openrouter.ai/api/v1"     "$u6"
+assert_eq "agent 6 api_key"  "sk-or-test"                       "$k6"
+
+# ============================================================
+echo ""
+echo "=== 2. Minimal config (defaults) ==="
+
+cat > "$TMPDIR/minimal.json" <<'EOF'
+{
+  "prompt": "task.md",
+  "agents": [
+    { "count": 2, "model": "claude-sonnet-4-5" }
+  ]
+}
+EOF
+
+assert_eq "prompt"      "task.md"                    "$(parse_prompt "$TMPDIR/minimal.json")"
+assert_eq "setup empty" ""                           "$(parse_setup "$TMPDIR/minimal.json")"
+assert_eq "max_idle default" "3"                     "$(parse_max_idle "$TMPDIR/minimal.json")"
+assert_eq "git name default" "swarm-agent"           "$(parse_git_name "$TMPDIR/minimal.json")"
+assert_eq "git email default" "agent@claude-swarm.local" "$(parse_git_email "$TMPDIR/minimal.json")"
+assert_eq "total agents" "2"                         "$(parse_num_agents "$TMPDIR/minimal.json")"
+
+TSV=$(parse_agents_tsv "$TMPDIR/minimal.json")
+assert_eq "all same model" "2" "$(echo "$TSV" | grep -c 'claude-sonnet-4-5')"
+
+# ============================================================
+echo ""
+echo "=== 3. Missing prompt field ==="
+
+cat > "$TMPDIR/noprompt.json" <<'EOF'
+{
+  "agents": [{ "count": 1, "model": "claude-opus-4-6" }]
+}
+EOF
+
+assert_eq "prompt is empty" "" "$(parse_prompt "$TMPDIR/noprompt.json")"
+
+# ============================================================
+echo ""
+echo "=== 4. Env-var fallback (synthetic TSV) ==="
+
+CLAUDE_MODEL="claude-opus-4-6"
+NUM_AGENTS=3
+: > "$TMPDIR/env-agents.tsv"
+for _i in $(seq 1 "$NUM_AGENTS"); do
+    printf '%s\t\t\n' "$CLAUDE_MODEL" >> "$TMPDIR/env-agents.tsv"
+done
+
+assert_eq "line count" "3" "$(wc -l < "$TMPDIR/env-agents.tsv" | tr -d ' ')"
+
+AGENT_IDX=0
+while IFS=$'\t' read -r m u k; do
+    AGENT_IDX=$((AGENT_IDX + 1))
+done < "$TMPDIR/env-agents.tsv"
+assert_eq "agents iterated" "3" "$AGENT_IDX"
+
+IFS=$'\t' read -r m u k < "$TMPDIR/env-agents.tsv"
+assert_eq "env model"    "claude-opus-4-6" "$m"
+assert_eq "env base_url" ""               "$u"
+assert_eq "env api_key"  ""               "$k"
+
+# ============================================================
+echo ""
+echo "=== 5. Single agent ==="
+
+cat > "$TMPDIR/single.json" <<'EOF'
+{
+  "prompt": "p.md",
+  "agents": [{ "count": 1, "model": "claude-opus-4-6" }]
+}
+EOF
+
+assert_eq "total agents" "1" "$(parse_num_agents "$TMPDIR/single.json")"
+TSV=$(parse_agents_tsv "$TMPDIR/single.json")
+assert_eq "line count" "1" "$(echo "$TSV" | wc -l | tr -d ' ')"
+
+# ============================================================
+echo ""
+echo "=== 6. All custom endpoints (no inherited key) ==="
+
+cat > "$TMPDIR/allcustom.json" <<'EOF'
+{
+  "prompt": "p.md",
+  "agents": [
+    { "count": 1, "model": "m1", "base_url": "https://a.com", "api_key": "k1" },
+    { "count": 2, "model": "m2", "base_url": "https://b.com", "api_key": "k2" }
+  ]
+}
+EOF
+
+assert_eq "total agents" "3" "$(parse_num_agents "$TMPDIR/allcustom.json")"
+TSV=$(parse_agents_tsv "$TMPDIR/allcustom.json")
+assert_eq "no empty keys" "0" "$(echo "$TSV" | awk -F'\t' '$3 == ""' | wc -l | tr -d ' ')"
+
+# ============================================================
+echo ""
+echo "=== 7. Large count ==="
+
+cat > "$TMPDIR/large.json" <<'EOF'
+{
+  "prompt": "p.md",
+  "agents": [{ "count": 20, "model": "claude-opus-4-6" }]
+}
+EOF
+
+assert_eq "total agents" "20" "$(parse_num_agents "$TMPDIR/large.json")"
+TSV=$(parse_agents_tsv "$TMPDIR/large.json")
+assert_eq "line count" "20" "$(echo "$TSV" | wc -l | tr -d ' ')"
+
+# ============================================================
+echo ""
+echo "=== 8. Partial git_user (only name) ==="
+
+cat > "$TMPDIR/partialuser.json" <<'EOF'
+{
+  "prompt": "p.md",
+  "git_user": { "name": "custom-name" },
+  "agents": [{ "count": 1, "model": "claude-opus-4-6" }]
+}
+EOF
+
+assert_eq "git name override"  "custom-name"              "$(parse_git_name "$TMPDIR/partialuser.json")"
+assert_eq "git email fallback" "agent@claude-swarm.local"  "$(parse_git_email "$TMPDIR/partialuser.json")"
+
+# ============================================================
+echo ""
+echo "==============================="
+echo "  ${PASS} passed, ${FAIL} failed"
+echo "==============================="
+
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

- Prefix all project env vars with `SWARM_` to avoid collisions.
- Add `swarm.json` config file for heterogeneous agent groups
  (e.g. 2 Opus + 3 Sonnet + 4 OpenRouter agents in one swarm).
- Add always-on TUI dashboard (`dashboard.sh`) showing agent
  status, models, session counts, and recent commits with model
  attribution.
- Add interactive setup wizard (`setup.sh`) using whiptail to
  generate `swarm.json`.
- Add `wait` and `post-process` commands to `launch.sh` for
  automated completion detection and post-processing workflows.
- Tag git author name with model (e.g. `swarm-agent [sonnet-4-6]`)
  for commit attribution in mixed-model runs.
- Add `--config` flag to `test.sh` and `--dashboard` to
  `launch.sh start`.
- Add `test_config.sh` unit tests for `jq` config parsing.
- Extract command reference to `USAGE.md`, slim down `README.md`.

## Test plan

- [x] `./test_config.sh` passes (no Docker/API key needed).
- [x] `ANTHROPIC_API_KEY="..." ./test.sh` with 1, 2, 3 agents.
- [x] `ANTHROPIC_API_KEY="..." SWARM_MODEL="claude-sonnet-4-6" ./test.sh`
- [x] `./test.sh --config swarm.json` with mixed-model config.
- [x] `./launch.sh start --dashboard` shows TUI with model tags.
- [x] `[p]` in dashboard triggers post-processing.
- [x] `./setup.sh` generates valid `swarm.json`.