### PR TITLE
Add per-agent cost and usage tracking to dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ No orchestrator, no message passing.
 Based on the agent-team pattern from
 [Building a C Compiler with Large Language Models](https://www.anthropic.com/engineering/building-c-compiler).
 
+## Prerequisites
+
+- Docker
+- bash, git, jq, bc
+- An Anthropic API key (or compatible endpoint)
+
 ## Setup
 
 Add as a submodule:

--- a/USAGE.md
+++ b/USAGE.md
@@ -31,8 +31,9 @@ export SWARM_PROMPT="path/to/prompt.md"
 ./dashboard.sh                 # Attach to TUI dashboard.
 ```
 
-Shows agent status, models, session counts, and recent
-commits (with model attribution).
+Shows agent status, models, cost, token usage, agentic
+turns, duration, and recent commits (with model
+attribution). Stats update live as sessions complete.
 
 Keyboard shortcuts:
 
@@ -94,6 +95,19 @@ or automatically through `./launch.sh wait`.
 
 The post-process agent clones the same bare repo, sees all
 agent commits on `agent-work`, runs its prompt, and pushes.
+
+## Cost tracking
+
+The dashboard shows per-agent and total cost, tokens, and
+duration in real time. For a non-interactive summary:
+
+```bash
+./costs.sh                     # Table output.
+./costs.sh --json              # Machine-readable JSON.
+```
+
+Stats are collected per session inside each container
+(`agent_logs/stats_agent_*.tsv`) and read on demand.
 
 ## Cleanup
 

--- a/costs.sh
+++ b/costs.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+set -euo pipefail
+
+# Print cost and usage summary for all swarm agents.
+# Usage: ./costs.sh [--json]
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+PROJECT="$(basename "$REPO_ROOT")"
+IMAGE_NAME="${PROJECT}-agent"
+JSON_MODE=false
+
+if [ "${1:-}" = "--json" ]; then
+    JSON_MODE=true
+fi
+
+read_agent_stats() {
+    local name=$1 agent_id=$2
+    local stats_file="agent_logs/stats_agent_${agent_id}.tsv"
+    local raw
+    raw=$(docker exec "$name" cat "/workspace/$stats_file" 2>/dev/null || true)
+    if [ -z "$raw" ]; then
+        echo "0 0 0 0 0 0 0"
+        return
+    fi
+    echo "$raw" | awk -F'\t' '{
+        cost += $2; tok_in += $3; tok_out += $4;
+        cache += $5; dur += $7; turns += $9; sessions++
+    } END {
+        printf "%s %d %d %d %d %d %d\n",
+            cost, tok_in, tok_out, cache, dur, turns, sessions
+    }'
+}
+
+format_tokens() {
+    local n=${1:-0}
+    if [ "$n" -ge 1000000 ]; then
+        printf '%.1fM' "$(echo "$n / 1000000" | bc -l)"
+    elif [ "$n" -ge 1000 ]; then
+        printf '%.0fk' "$(echo "$n / 1000" | bc -l)"
+    else
+        printf '%d' "$n"
+    fi
+}
+
+containers=$(docker ps -a --filter "name=${IMAGE_NAME}-" \
+    --format '{{.Names}}' 2>/dev/null | sort -V || true)
+
+if [ -z "$containers" ]; then
+    echo "No swarm containers found." >&2
+    exit 1
+fi
+
+total_cost=0
+total_in=0
+total_out=0
+total_cache=0
+total_dur=0
+total_turns=0
+total_sessions=0
+json_agents="["
+
+if ! $JSON_MODE; then
+    printf "%-4s %-20s %9s %10s %10s %6s %8s %8s\n" \
+        "#" "Model" "Cost" "Input" "Output" "Cache" "Turns" "Time"
+    printf "%s\n" "$(printf '%.0s─' $(seq 1 78))"
+fi
+
+first_json=true
+
+for cname in $containers; do
+    agent_id="${cname##*-}"
+    state=$(docker inspect -f '{{.State.Status}}' "$cname" 2>/dev/null || echo "?")
+    model=$(docker inspect -f '{{range .Config.Env}}{{println .}}{{end}}' \
+        "$cname" 2>/dev/null | grep '^CLAUDE_MODEL=' | head -1 | cut -d= -f2- || true)
+    model="${model:-unknown}"
+    short="${model/claude-/}"
+
+    stats=$(read_agent_stats "$cname" "$agent_id")
+    a_cost=$(echo "$stats" | awk '{print $1}')
+    a_in=$(echo "$stats" | awk '{print $2}')
+    a_out=$(echo "$stats" | awk '{print $3}')
+    a_cache=$(echo "$stats" | awk '{print $4}')
+    a_dur=$(echo "$stats" | awk '{print $5}')
+    a_turns=$(echo "$stats" | awk '{print $6}')
+    a_sessions=$(echo "$stats" | awk '{print $7}')
+
+    total_cost=$(echo "$total_cost + $a_cost" | bc)
+    total_in=$((total_in + a_in))
+    total_out=$((total_out + a_out))
+    total_cache=$((total_cache + a_cache))
+    total_dur=$((total_dur + a_dur))
+    total_turns=$((total_turns + a_turns))
+    total_sessions=$((total_sessions + a_sessions))
+
+    dur_s=$((a_dur / 1000))
+
+    if $JSON_MODE; then
+        $first_json || json_agents="${json_agents},"
+        first_json=false
+        json_agents="${json_agents}{\"id\":${agent_id},\"model\":\"${model}\",\"state\":\"${state}\","
+        json_agents="${json_agents}\"cost_usd\":${a_cost},\"input_tokens\":${a_in},"
+        json_agents="${json_agents}\"output_tokens\":${a_out},\"cache_read_tokens\":${a_cache},"
+        json_agents="${json_agents}\"duration_ms\":${a_dur},\"turns\":${a_turns},\"sessions\":${a_sessions}}"
+    else
+        printf "%-4s %-20s \$%8.4f %10s %10s %6s %8s %7ds\n" \
+            "$agent_id" "$short" "$a_cost" \
+            "$(format_tokens "$a_in")" "$(format_tokens "$a_out")" \
+            "$(format_tokens "$a_cache")" "$a_turns" "$dur_s"
+    fi
+done
+
+json_agents="${json_agents}]"
+
+if $JSON_MODE; then
+    printf '{"agents":%s,"total":{"cost_usd":%s,"input_tokens":%d,"output_tokens":%d,"cache_read_tokens":%d,"duration_ms":%d,"turns":%d,"sessions":%d}}\n' \
+        "$json_agents" "$total_cost" "$total_in" "$total_out" \
+        "$total_cache" "$total_dur" "$total_turns" "$total_sessions"
+else
+    printf "%s\n" "$(printf '%.0s─' $(seq 1 78))"
+    t_dur_s=$((total_dur / 1000))
+    printf "%-4s %-20s \$%8.4f %10s %10s %6s %8s %7ds\n" \
+        "" "TOTAL" "$total_cost" \
+        "$(format_tokens "$total_in")" "$(format_tokens "$total_out")" \
+        "$(format_tokens "$total_cache")" "$total_turns" "$t_dur_s"
+    printf "\n%d agents, %d sessions, \$%.4f total cost\n" \
+        "$(echo "$containers" | wc -l)" "$total_sessions" "$total_cost"
+fi

--- a/costs.sh
+++ b/costs.sh
@@ -99,7 +99,11 @@ for cname in $containers; do
     if $JSON_MODE; then
         $first_json || json_agents="${json_agents},"
         first_json=false
-        json_agents="${json_agents}{\"id\":${agent_id},\"model\":\"${model}\",\"state\":\"${state}\","
+        id_json="${agent_id}"
+        if ! [[ "$agent_id" =~ ^[0-9]+$ ]]; then
+            id_json="\"${agent_id}\""
+        fi
+        json_agents="${json_agents}{\"id\":${id_json},\"model\":\"${model}\",\"state\":\"${state}\","
         json_agents="${json_agents}\"cost_usd\":${a_cost},\"input_tokens\":${a_in},"
         json_agents="${json_agents}\"output_tokens\":${a_out},\"cache_read_tokens\":${a_cache},"
         json_agents="${json_agents}\"duration_ms\":${a_dur},\"turns\":${a_turns},\"sessions\":${a_sessions}}"
@@ -114,8 +118,9 @@ done
 json_agents="${json_agents}]"
 
 if $JSON_MODE; then
+    total_cost_json=$(printf '%.6f' "$total_cost")
     printf '{"agents":%s,"total":{"cost_usd":%s,"input_tokens":%d,"output_tokens":%d,"cache_read_tokens":%d,"duration_ms":%d,"turns":%d,"sessions":%d}}\n' \
-        "$json_agents" "$total_cost" "$total_in" "$total_out" \
+        "$json_agents" "$total_cost_json" "$total_in" "$total_out" \
         "$total_cache" "$total_dur" "$total_turns" "$total_sessions"
 else
     printf "%s\n" "$(printf '%.0s─' $(seq 1 82))"

--- a/costs.sh
+++ b/costs.sh
@@ -64,7 +64,7 @@ json_agents="["
 if ! $JSON_MODE; then
     printf "%-4s %-20s %9s %10s %10s %6s %8s %8s\n" \
         "#" "Model" "Cost" "Input" "Output" "Cache" "Turns" "Time"
-    printf "%s\n" "$(printf '%.0s─' $(seq 1 78))"
+    printf "%s\n" "$(printf '%.0s─' $(seq 1 82))"
 fi
 
 first_json=true
@@ -118,7 +118,7 @@ if $JSON_MODE; then
         "$json_agents" "$total_cost" "$total_in" "$total_out" \
         "$total_cache" "$total_dur" "$total_turns" "$total_sessions"
 else
-    printf "%s\n" "$(printf '%.0s─' $(seq 1 78))"
+    printf "%s\n" "$(printf '%.0s─' $(seq 1 82))"
     t_dur_s=$((total_dur / 1000))
     printf "%-4s %-20s \$%8.4f %10s %10s %6s %8s %7ds\n" \
         "" "TOTAL" "$total_cost" \

--- a/launch.sh
+++ b/launch.sh
@@ -184,7 +184,6 @@ cmd_stop() {
         NAME="${IMAGE_NAME}-${i}"
         docker stop "$NAME" 2>/dev/null && echo "  stopped ${NAME}" \
             || echo "  ${NAME} not running"
-        docker rm "$NAME" 2>/dev/null || true
     done
 }
 

--- a/launch.sh
+++ b/launch.sh
@@ -322,8 +322,6 @@ cmd_post_process() {
         break
     done
 
-    docker rm "$NAME" 2>/dev/null || true
-
     echo ""
     echo "--- Harvesting results ---"
     "$SWARM_DIR/harvest.sh"


### PR DESCRIPTION
## Summary

- Capture per-session cost, tokens, cache hits, turns, and duration
  from Claude Code's `--output-format json` output inside the harness.
- Show live cost/token/turns/time columns in the TUI dashboard,
  including a post-process row and totals.
- Add `costs.sh` standalone script with table and `--json` output.
- Use `docker cp` to read stats from both running and exited
  containers. Keep exited containers so costs survive `stop`.
- Add prerequisites section to README.

## Test plan

- [x] 1-agent Opus smoke test -- stats file written, costs.sh works.
- [x] 5-agent mixed model (2 Sonnet, 2 Haiku, 1 Opus) -- all costs populated.
- [x] 2-agent + post-process via `launch.sh post-process` -- PP row shows in costs.
- [x] `costs.sh --json` produces valid JSON with quoted non-numeric IDs.
- [x] Separator width matches table columns.
- [x] New run clears stale containers via `cmd_start` docker rm -f.