### PR TITLE
Inject git coordination rules via system prompt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN git config --global --add safe.directory '*' \
     && git config --global protocol.file.allow always
 
 COPY --chmod=755 harness.sh /harness.sh
+COPY --chmod=644 agent-system-prompt.md /agent-system-prompt.md
 
 WORKDIR /workspace
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ with `SWARM_CONFIG=/path/to/config.json`:
       "api_key": "sk-or-..."
     }
   ],
+  "inject_git_rules": true,
   "post_process": {
     "prompt": "prompts/review.md",
     "model": "claude-opus-4-6"
@@ -88,6 +89,11 @@ with `SWARM_CONFIG=/path/to/config.json`:
 Agent groups without `api_key` use `ANTHROPIC_API_KEY` from
 the environment. Total agent count is the sum of all `count`
 fields. Requires `jq` on the host.
+
+By default, agents receive git coordination rules
+(commit/push/rebase workflow) appended to their system
+prompt. Set `"inject_git_rules": false` in the config to
+disable this, e.g. when you want full control over the prompt.
 
 ### Environment variables (simple case)
 
@@ -100,6 +106,7 @@ fields. Requires `jq` on the host.
 | SWARM_MODEL | claude-opus-4-6 | Model. |
 | SWARM_NUM_AGENTS | 3 | Container count. |
 | SWARM_MAX_IDLE | 3 | Idle sessions before exit. |
+| SWARM_INJECT_GIT_RULES | true | Inject git coordination rules. |
 | SWARM_GIT_USER_NAME | swarm-agent | Git author name. |
 | SWARM_GIT_USER_EMAIL | agent@claude-swarm.local | Git email. |
 | ANTHROPIC_BASE_URL | | Override API URL. |

--- a/USAGE.md
+++ b/USAGE.md
@@ -96,6 +96,16 @@ or automatically through `./launch.sh wait`.
 The post-process agent clones the same bare repo, sees all
 agent commits on `agent-work`, runs its prompt, and pushes.
 
+## Git coordination
+
+Agents automatically receive git rules (commit, push, rebase
+workflow) via a system prompt appendix. This means your task
+prompt does not need to explain the git machinery -- just
+describe the work.
+
+To disable, set `"inject_git_rules": false` in `swarm.json`
+or `SWARM_INJECT_GIT_RULES=false` as an env var.
+
 ## Cost tracking
 
 The dashboard shows per-agent and total cost, tokens, and

--- a/USAGE.md
+++ b/USAGE.md
@@ -49,7 +49,7 @@ Re-run `./dashboard.sh` to re-attach while agents run.
 
 ## Testing
 
-Basic smoke test:
+Basic smoke test (uses injected git rules):
 
 ```bash
 ANTHROPIC_API_KEY="sk-..." ./test.sh
@@ -67,6 +67,15 @@ With a config file (mixed models):
 ```bash
 ANTHROPIC_API_KEY="sk-..." ./test.sh --config swarm.json
 ```
+
+Backward compatibility (explicit git commands in prompt,
+no git rule injection):
+
+```bash
+ANTHROPIC_API_KEY="sk-..." ./test.sh --no-inject
+```
+
+Flags combine freely: `./test.sh --config swarm.json --no-inject`.
 
 `test.sh` always uses its own built-in prompt regardless of
 what the config file specifies.

--- a/agent-system-prompt.md
+++ b/agent-system-prompt.md
@@ -1,0 +1,33 @@
+You are agent ${AGENT_ID} in a collaborative swarm. Multiple agents
+work in parallel on the same codebase, sharing a single branch
+called `agent-work`.
+
+## Git coordination
+
+After completing your assigned task, push your changes:
+
+```bash
+git add -A  # Or specific files.
+git commit -m "concise description of what you did"
+git pull --rebase origin agent-work
+git push origin agent-work
+```
+
+If the push fails because another agent pushed first, rebase
+and retry:
+
+```bash
+git pull --rebase origin agent-work
+git push origin agent-work
+```
+
+If a rebase conflict occurs, resolve it, then `git rebase
+--continue` and push.
+
+## Rules
+
+- Keep commits atomic. One logical change per commit.
+- Do NOT modify files outside the scope of your task unless
+  necessary -- other agents may be working on them.
+- After pushing, stop. Do NOT loop back or pick another task.
+  The harness will restart you with the latest state.

--- a/harness.sh
+++ b/harness.sh
@@ -8,6 +8,7 @@ CLAUDE_MODEL="${CLAUDE_MODEL:-claude-opus-4-6}"
 AGENT_PROMPT="${AGENT_PROMPT:?AGENT_PROMPT is required.}"
 AGENT_SETUP="${AGENT_SETUP:-}"
 MAX_IDLE="${MAX_IDLE:-3}"
+INJECT_GIT_RULES="${INJECT_GIT_RULES:-true}"
 STATS_FILE="agent_logs/stats_agent_${AGENT_ID}.tsv"
 
 GIT_USER_NAME="${GIT_USER_NAME:-swarm-agent}"
@@ -65,9 +66,15 @@ while true; do
 
     echo "[harness:${AGENT_ID}] Starting session at ${COMMIT}..."
 
+    APPEND_ARGS=()
+    if [ "$INJECT_GIT_RULES" = "true" ] && [ -f /agent-system-prompt.md ]; then
+        APPEND_ARGS+=(--append-system-prompt-file /agent-system-prompt.md)
+    fi
+
     claude --dangerously-skip-permissions \
            -p "$(cat "$AGENT_PROMPT")" \
            --model "$CLAUDE_MODEL" \
+           "${APPEND_ARGS[@]+"${APPEND_ARGS[@]}"}" \
            --output-format json > "$LOGFILE" 2>"${LOGFILE}.err" || true
 
     # Extract usage stats from JSON output.

--- a/launch.sh
+++ b/launch.sh
@@ -26,6 +26,7 @@ if [ -n "$CONFIG_FILE" ]; then
     AGENT_PROMPT=$(jq -r '.prompt // empty' "$CONFIG_FILE")
     AGENT_SETUP=$(jq -r '.setup // empty' "$CONFIG_FILE")
     MAX_IDLE=$(jq -r '.max_idle // 3' "$CONFIG_FILE")
+    INJECT_GIT_RULES=$(jq -r '.inject_git_rules // true' "$CONFIG_FILE")
     GIT_USER_NAME=$(jq -r '.git_user.name // "swarm-agent"' "$CONFIG_FILE")
     GIT_USER_EMAIL=$(jq -r '.git_user.email // "agent@claude-swarm.local"' "$CONFIG_FILE")
     NUM_AGENTS=$(jq '[.agents[].count] | add' "$CONFIG_FILE")
@@ -35,6 +36,7 @@ else
     AGENT_PROMPT="${SWARM_PROMPT:-}"
     AGENT_SETUP="${SWARM_SETUP:-}"
     MAX_IDLE="${SWARM_MAX_IDLE:-3}"
+    INJECT_GIT_RULES="${SWARM_INJECT_GIT_RULES:-true}"
     GIT_USER_NAME="${SWARM_GIT_USER_NAME:-swarm-agent}"
     GIT_USER_EMAIL="${SWARM_GIT_USER_EMAIL:-agent@claude-swarm.local}"
 fi
@@ -159,6 +161,7 @@ cmd_start() {
             -e "MAX_IDLE=${MAX_IDLE}" \
             -e "GIT_USER_NAME=${agent_git_name}" \
             -e "GIT_USER_EMAIL=${GIT_USER_EMAIL}" \
+            -e "INJECT_GIT_RULES=${INJECT_GIT_RULES}" \
             -e "AGENT_ID=${AGENT_IDX}" \
             "$IMAGE_NAME"
     done < "$AGENTS_TSV"
@@ -303,6 +306,7 @@ cmd_post_process() {
         -e "MAX_IDLE=${MAX_IDLE}" \
         -e "GIT_USER_NAME=${GIT_USER_NAME}" \
         -e "GIT_USER_EMAIL=${GIT_USER_EMAIL}" \
+        -e "INJECT_GIT_RULES=${INJECT_GIT_RULES}" \
         -e "AGENT_ID=post" \
         "$IMAGE_NAME"
 

--- a/test.sh
+++ b/test.sh
@@ -3,29 +3,57 @@ set -euo pipefail
 
 # Smoke test: launch agents with a counting prompt, verify results.
 # Each agent N writes test-results/agent-N.txt with N*100..N*100+99.
+#
+# Usage: ./test.sh [--config FILE] [--no-inject]
+#   --config FILE   Use a swarm.json for mixed-model testing.
+#   --no-inject     Disable git rule injection; prompt includes
+#                   explicit git commands (backward compat test).
 
 SWARM_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 PROJECT="$(basename "$REPO_ROOT")"
 BARE_REPO="/tmp/${PROJECT}-upstream.git"
 REVIEW_DIR="/tmp/${PROJECT}-test-review"
+INJECT_DIR="/tmp/${PROJECT}-test-inject"
 TIMEOUT="${TIMEOUT:-600}"
 
 CONFIG_FILE=""
-if [ "${1:-}" = "--config" ] && [ -n "${2:-}" ]; then
-    CONFIG_FILE="$2"
-    if [ ! -f "$CONFIG_FILE" ]; then
-        echo "ERROR: Config file ${CONFIG_FILE} not found." >&2
-        exit 1
-    fi
+NO_INJECT=false
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --config)
+            CONFIG_FILE="${2:-}"
+            if [ -z "$CONFIG_FILE" ]; then
+                echo "ERROR: --config requires a file path." >&2
+                exit 1
+            fi
+            shift 2 ;;
+        --no-inject) NO_INJECT=true; shift ;;
+        *) echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+done
+
+if [ -n "$CONFIG_FILE" ] && [ ! -f "$CONFIG_FILE" ]; then
+    echo "ERROR: Config file ${CONFIG_FILE} not found." >&2
+    exit 1
+fi
+
+if [ -n "$CONFIG_FILE" ]; then
     NUM_AGENTS=$(jq '[.agents[].count] | add' "$CONFIG_FILE")
 else
     NUM_AGENTS="${SWARM_NUM_AGENTS:-2}"
 fi
 
-# Write the smoke test prompt as a temp file and commit it.
+# Two prompt variants: default relies on injected git rules,
+# --no-inject uses explicit git commands for backward compat.
 PROMPT_FILE=".claude-swarm-smoke-test.md"
-cat > "$REPO_ROOT/$PROMPT_FILE" <<'PROMPT'
+SETUP_FILE=".claude-swarm-smoke-setup.sh"
+
+write_prompt() {
+    local dest="$1"
+
+    if $NO_INJECT; then
+        cat > "$dest/$PROMPT_FILE" <<'PROMPT'
 # Smoke Test: Deterministic Counting
 
 You are agent $AGENT_ID in an infrastructure smoke test.
@@ -71,27 +99,70 @@ git push origin agent-work
 - The file must contain exactly 100 lines, one number per line.
 - Use the exact bash commands above. Do not improvise.
 PROMPT
+    else
+        cat > "$dest/$PROMPT_FILE" <<'PROMPT'
+# Smoke Test: Deterministic Counting
 
-# Write a setup script that requires root (tests sudo in harness).
-SETUP_FILE=".claude-swarm-smoke-setup.sh"
-cat > "$REPO_ROOT/$SETUP_FILE" <<'SETUP'
+You are agent $AGENT_ID in an infrastructure smoke test.
+Your ONLY task is to create one file and commit it.
+
+## Steps
+
+1. Read the AGENT_ID environment variable:
+
+```bash
+echo $AGENT_ID
+```
+
+2. Create the output file. The file must be named
+   `test-results/agent-{AGENT_ID}.txt` and contain numbers
+   from `AGENT_ID * 100` to `AGENT_ID * 100 + 99`, one per
+   line. For example, agent 1 writes 100..199, agent 2 writes
+   200..299, agent 3 writes 300..399.
+
+```bash
+mkdir -p test-results
+START=$((AGENT_ID * 100))
+END=$((START + 99))
+seq $START $END > test-results/agent-${AGENT_ID}.txt
+```
+
+3. Commit your work with message "Smoke test: agent ${AGENT_ID} counting".
+
+4. Stop. Do NOT loop, do NOT pick another task.
+
+## Rules
+
+- Do NOT modify any existing files.
+- Do NOT create any files other than test-results/agent-{AGENT_ID}.txt.
+- The file must contain exactly 100 lines, one number per line.
+PROMPT
+    fi
+
+    cat > "$dest/$SETUP_FILE" <<'SETUP'
 #!/bin/bash
 set -euo pipefail
 apt-get update -qq > /dev/null
 echo "Smoke test setup complete."
 SETUP
+}
 
-cd "$REPO_ROOT"
-git add -f "$PROMPT_FILE" "$SETUP_FILE"
-git commit --quiet -m "tmp: smoke test prompt"
-PROMPT_COMMITTED=true
+# Write prompt to repo root (uncommitted) so launch.sh's file-exists
+# check passes. Files are injected into the bare repo after launch.
+write_prompt "$REPO_ROOT"
 
-# When using a config file, create a temp copy with prompt/setup overridden.
 TEMP_CONFIG=""
 if [ -n "$CONFIG_FILE" ]; then
     TEMP_CONFIG=$(mktemp /tmp/${PROJECT}-test-config.XXXXXX.json)
-    jq --arg p "$PROMPT_FILE" --arg s "$SETUP_FILE" \
-        '.prompt = $p | .setup = $s' "$CONFIG_FILE" > "$TEMP_CONFIG"
+    if $NO_INJECT; then
+        jq --arg p "$PROMPT_FILE" --arg s "$SETUP_FILE" \
+            '.prompt = $p | .setup = $s | .inject_git_rules = false' \
+            "$CONFIG_FILE" > "$TEMP_CONFIG"
+    else
+        jq --arg p "$PROMPT_FILE" --arg s "$SETUP_FILE" \
+            '.prompt = $p | .setup = $s' \
+            "$CONFIG_FILE" > "$TEMP_CONFIG"
+    fi
 fi
 
 cleanup() {
@@ -109,15 +180,20 @@ cleanup() {
             SWARM_NUM_AGENTS="${NUM_AGENTS}" \
             "$SWARM_DIR/launch.sh" stop 2>/dev/null || true
     fi
-    rm -rf "$REVIEW_DIR" /tmp/${PROJECT}-upstream.git
-
-    if [ "${PROMPT_COMMITTED:-}" = true ]; then
-        git reset --quiet --hard HEAD~1
-    fi
+    rm -rf "$REVIEW_DIR" "$INJECT_DIR" /tmp/${PROJECT}-upstream.git
+    rm -f "$REPO_ROOT/$PROMPT_FILE" "$REPO_ROOT/$SETUP_FILE"
 }
 trap cleanup EXIT
 
+INJECT_ENV="true"
+if $NO_INJECT; then INJECT_ENV="false"; fi
+
 echo "=== Smoke test: ${NUM_AGENTS} agents ==="
+if $NO_INJECT; then
+    echo "  mode: --no-inject (explicit git in prompt)"
+else
+    echo "  mode: default (git rules injected via system prompt)"
+fi
 echo ""
 
 if [ -n "$TEMP_CONFIG" ]; then
@@ -129,8 +205,29 @@ else
         SWARM_SETUP="$SETUP_FILE" \
         ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY}" \
         SWARM_NUM_AGENTS="${NUM_AGENTS}" \
+        SWARM_INJECT_GIT_RULES="${INJECT_ENV}" \
         "$SWARM_DIR/launch.sh" start
 fi
+
+# Inject prompt + setup into bare repo via a temp clone.
+# Agents fetch at the start of each session so they pick this up
+# before their first claude invocation.
+echo ""
+echo "--- Injecting test prompt into bare repo ---"
+rm -rf "$INJECT_DIR"
+git clone --quiet "$BARE_REPO" "$INJECT_DIR"
+cd "$INJECT_DIR"
+git checkout --quiet agent-work
+write_prompt "$INJECT_DIR"
+git add "$PROMPT_FILE" "$SETUP_FILE"
+git -c user.name="test" -c user.email="test@test" \
+    commit --quiet -m "tmp: smoke test prompt"
+git push --quiet origin agent-work
+rm -rf "$INJECT_DIR"
+cd "$REPO_ROOT"
+
+# Clean uncommitted files from working tree.
+rm -f "$REPO_ROOT/$PROMPT_FILE" "$REPO_ROOT/$SETUP_FILE"
 
 echo ""
 echo "--- Waiting for agents (timeout ${TIMEOUT}s) ---"
@@ -203,7 +300,7 @@ else
     for i in $(seq 1 "$NUM_AGENTS"); do
         if [ ! -f "test-results/agent-${i}.txt" ]; then
             echo ""
-            echo "--- ${IMAGE_NAME}-${i} docker logs ---"
+            echo "--- ${PROJECT}-agent-${i} docker logs ---"
             docker logs "${PROJECT}-agent-${i}" 2>&1 | tail -20
         fi
     done


### PR DESCRIPTION
## Summary
- Agents automatically receive git coordination rules (commit/push/rebase workflow) appended to their system prompt, so task prompts no longer need to explain the git machinery
- Opt out with `"inject_git_rules": false` in `swarm.json` or `SWARM_INJECT_GIT_RULES=false` as an env var
- Refactors `test.sh` to inject prompts into the bare repo via a temp clone instead of the dangerous `git commit` + `git reset --hard HEAD~1` pattern that could wipe uncommitted working tree changes
- Adds `--no-inject` flag to `test.sh` for backward compatibility testing (explicit git commands in prompt, no injection)

## Test plan
- [x] `./test.sh` with 2 agents -- simplified prompt, injected git rules -- PASS
- [x] `./test.sh --no-inject` with 2 agents -- explicit git prompt, no injection -- PASS
- [x] Working tree clean after both test runs (no `git reset --hard` damage)