### PR TITLE
Add effort level support, cache column, and test improvements

### DIFF
--- a/.claude-swarm-smoke-setup.sh
+++ b/.claude-swarm-smoke-setup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+apt-get update -qq > /dev/null
+echo "Smoke test setup complete."

--- a/.claude-swarm-smoke-test.md
+++ b/.claude-swarm-smoke-test.md
@@ -1,0 +1,47 @@
+# Smoke Test: Deterministic Counting
+
+You are agent $AGENT_ID in an infrastructure smoke test.
+Your ONLY task is to create two files and commit them.
+
+## Steps
+
+1. Read the AGENT_ID environment variable:
+
+```bash
+echo $AGENT_ID
+```
+
+2. Create the counting file. The file must be named
+   `test-results/agent-{AGENT_ID}.txt` and contain numbers
+   from `AGENT_ID * 100` to `AGENT_ID * 100 + 99`, one per
+   line. For example, agent 1 writes 100..199, agent 2 writes
+   200..299, agent 3 writes 300..399.
+
+```bash
+mkdir -p test-results
+START=$((AGENT_ID * 100))
+END=$((START + 99))
+seq $START $END > test-results/agent-${AGENT_ID}.txt
+```
+
+3. Reasoning checkpoint — think through this before proceeding:
+   Compute the sum of all 100 numbers you just wrote. The formula
+   for the sum of consecutive integers from a to b is:
+   sum = (b - a + 1) * (a + b) / 2
+
+   Write a second file `test-results/reasoning-{AGENT_ID}.txt`
+   containing exactly two lines:
+   - Line 1: the computed sum (a single integer)
+   - Line 2: a one-sentence explanation of how you derived it
+
+4. Commit your work with message "Smoke test: agent ${AGENT_ID} counting".
+
+5. Stop. Do NOT loop, do NOT pick another task.
+
+## Rules
+
+- Do NOT modify any existing files.
+- Only create test-results/agent-{AGENT_ID}.txt and
+  test-results/reasoning-{AGENT_ID}.txt.
+- The counting file must contain exactly 100 lines, one number per line.
+- The reasoning file must contain exactly 2 lines.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -20,6 +20,35 @@ elective.
 ## Testing
 
 - All tests must pass (`./test.sh --all`).
+- `./test.sh --unit` runs unit tests only (no Docker/API key).
+- `./test.sh --help` shows available flags.
+- Integration matrix covers effort levels (`low`, `medium`, `high`)
+  via env var and per-agent config.
+
+## Pull requests
+
+When asked to prepare a PR title and body:
+
+1. Run `git diff --stat origin/master..HEAD` and
+   `git log --oneline origin/master..HEAD` to understand scope.
+2. Title: imperative, concise, covers the main themes
+   (e.g., "Add effort level support, cache column, and test
+   improvements").
+3. Body format:
+
+```
+## Summary
+- Bullet per logical change. Focus on what and why, not
+  per-file diffs. Wrap to 79 chars.
+
+## Test plan
+- [ ] Checklist of concrete verification steps.
+```
+
+4. Keep summary bullets to 3-6. Group related commits into
+   one bullet rather than listing every commit.
+5. Test plan items should be runnable commands or observable
+   behaviors, not vague ("passes" not "looks good").
 
 ## Quality bars (non-procedural)
 

--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ with `SWARM_CONFIG=/path/to/config.json`:
   "setup": "scripts/setup.sh",
   "max_idle": 3,
   "agents": [
-    { "count": 2, "model": "claude-opus-4-6" },
-    { "count": 1, "model": "claude-sonnet-4-5" },
+    { "count": 2, "model": "claude-opus-4-6", "effort": "high" },
+    { "count": 1, "model": "claude-sonnet-4-6", "effort": "medium" },
     {
       "count": 3,
       "model": "openrouter/custom",
@@ -81,7 +81,8 @@ with `SWARM_CONFIG=/path/to/config.json`:
   "inject_git_rules": true,
   "post_process": {
     "prompt": "prompts/review.md",
-    "model": "claude-opus-4-6"
+    "model": "claude-opus-4-6",
+    "effort": "low"
   }
 }
 ```
@@ -89,6 +90,10 @@ with `SWARM_CONFIG=/path/to/config.json`:
 Agent groups without `api_key` use `ANTHROPIC_API_KEY` from
 the environment. Total agent count is the sum of all `count`
 fields. Requires `jq` on the host.
+
+The `effort` field controls Claude's adaptive reasoning depth
+(`low`, `medium`, `high`). Supported on Opus 4.6 and Sonnet 4.6.
+Omit it to use the model's default (`high`).
 
 By default, agents receive git coordination rules
 (commit/push/rebase workflow) appended to their system
@@ -106,6 +111,7 @@ disable this, e.g. when you want full control over the prompt.
 | SWARM_MODEL | claude-opus-4-6 | Model. |
 | SWARM_NUM_AGENTS | 3 | Container count. |
 | SWARM_MAX_IDLE | 3 | Idle sessions before exit. |
+| SWARM_EFFORT | | Reasoning effort: low, medium, high. |
 | SWARM_INJECT_GIT_RULES | true | Inject git coordination rules. |
 | SWARM_GIT_USER_NAME | swarm-agent | Git author name. |
 | SWARM_GIT_USER_EMAIL | agent@claude-swarm.local | Git email. |

--- a/costs.sh
+++ b/costs.sh
@@ -44,6 +44,17 @@ format_tokens() {
     fi
 }
 
+format_duration() {
+    local s=$1
+    if [ "$s" -ge 3600 ]; then
+        printf '%dh %02dm' $((s / 3600)) $(((s % 3600) / 60))
+    elif [ "$s" -ge 60 ]; then
+        printf '%dm %02ds' $((s / 60)) $((s % 60))
+    else
+        printf '%ds' "$s"
+    fi
+}
+
 containers=$(docker ps -a --filter "name=${IMAGE_NAME}-" \
     --format '{{.Names}}' 2>/dev/null | sort -V || true)
 
@@ -108,10 +119,10 @@ for cname in $containers; do
         json_agents="${json_agents}\"output_tokens\":${a_out},\"cache_read_tokens\":${a_cache},"
         json_agents="${json_agents}\"duration_ms\":${a_dur},\"turns\":${a_turns},\"sessions\":${a_sessions}}"
     else
-        printf "%-4s %-20s \$%8.4f %10s %10s %6s %8s %7ds\n" \
+        printf "%-4s %-20s \$%8.4f %10s %10s %6s %8s %8s\n" \
             "$agent_id" "$short" "$a_cost" \
             "$(format_tokens "$a_in")" "$(format_tokens "$a_out")" \
-            "$(format_tokens "$a_cache")" "$a_turns" "$dur_s"
+            "$(format_tokens "$a_cache")" "$a_turns" "$(format_duration "$dur_s")"
     fi
 done
 
@@ -125,10 +136,10 @@ if $JSON_MODE; then
 else
     printf "%s\n" "$(printf '%.0s─' $(seq 1 82))"
     t_dur_s=$((total_dur / 1000))
-    printf "%-4s %-20s \$%8.4f %10s %10s %6s %8s %7ds\n" \
+    printf "%-4s %-20s \$%8.4f %10s %10s %6s %8s %8s\n" \
         "" "TOTAL" "$total_cost" \
         "$(format_tokens "$total_in")" "$(format_tokens "$total_out")" \
-        "$(format_tokens "$total_cache")" "$total_turns" "$t_dur_s"
+        "$(format_tokens "$total_cache")" "$total_turns" "$(format_duration "$t_dur_s")"
     printf "\n%d agents, %d sessions, \$%.4f total cost\n" \
         "$(echo "$containers" | wc -l)" "$total_sessions" "$total_cost"
 fi

--- a/dashboard.sh
+++ b/dashboard.sh
@@ -165,8 +165,8 @@ draw() {
     echo ""
 
     # Agent table header.
-    printf "  ${BOLD}%-3s %-16s %-10s %8s %9s %5s %7s${RESET}\n" \
-        "#" "Model" "Status" "Cost" "In/Out" "Turns" "Time"
+    printf "  ${BOLD}%-3s %-16s %-10s %8s %9s %6s %5s %7s${RESET}\n" \
+        "#" "Model" "Status" "Cost" "In/Out" "Cache" "Turns" "Time"
 
     local running_count=0 exited_count=0
     local total_cost=0 total_in=0 total_out=0 total_cache=0 total_dur=0 total_turns=0
@@ -233,14 +233,15 @@ draw() {
                 ;;
         esac
 
-        local cost_str in_out_str dur_str
+        local cost_str in_out_str cache_str dur_str
         cost_str=$(format_cost "$a_cost")
         in_out_str="$(format_tokens "$a_in")/$(format_tokens "$a_out")"
+        cache_str=$(format_tokens "$a_cache")
         dur_str=$(format_duration_ms "$a_dur")
 
         printf "  %-3s %-16s " "$i" "$short"
         printf "%b%-10s%b" "$status_color" "$status_text" "$RESET"
-        printf " %8s %9s %5s %7s\n" "$cost_str" "$in_out_str" "$a_turns" "$dur_str"
+        printf " %8s %9s %6s %5s %7s\n" "$cost_str" "$in_out_str" "$cache_str" "$a_turns" "$dur_str"
     done
 
     # Post-process row (if container exists).
@@ -254,11 +255,12 @@ draw() {
         pp_model="${pp_model:-unknown}"
         local pp_short="${pp_model/claude-/}"
 
-        local pp_stats pp_cost pp_in pp_out pp_dur pp_turns
+        local pp_stats pp_cost pp_in pp_out pp_cache pp_dur pp_turns
         pp_stats=$(read_agent_stats "$pp_name" "post")
         pp_cost=$(echo "$pp_stats" | awk '{print $1}')
         pp_in=$(echo "$pp_stats" | awk '{print $2}')
         pp_out=$(echo "$pp_stats" | awk '{print $3}')
+        pp_cache=$(echo "$pp_stats" | awk '{print $4}')
         pp_dur=$(echo "$pp_stats" | awk '{print $5}')
         pp_turns=$(echo "$pp_stats" | awk '{print $6}')
 
@@ -278,20 +280,22 @@ draw() {
         printf "  ${DIM}%s${RESET}\n" "$(printf '%.0s·' $(seq 1 $((TERM_COLS - 4))))"
         printf "  %-3s %-16s " "PP" "$pp_short"
         printf "%b%-10s%b" "$pp_status_color" "$pp_state" "$RESET"
-        printf " %8s %9s %5s %7s\n" \
+        printf " %8s %9s %6s %5s %7s\n" \
             "$(format_cost "$pp_cost")" \
             "$(format_tokens "$pp_in")/$(format_tokens "$pp_out")" \
+            "$(format_tokens "$pp_cache")" \
             "$pp_turns" "$(format_duration_ms "$pp_dur")"
     fi
 
     # Totals row.
     printf "  ${DIM}%s${RESET}\n" "$(printf '%.0s─' $(seq 1 $((TERM_COLS - 4))))"
-    local t_cost_str t_inout_str t_dur_str
+    local t_cost_str t_inout_str t_cache_str t_dur_str
     t_cost_str=$(format_cost "$total_cost")
     t_inout_str="$(format_tokens "$total_in")/$(format_tokens "$total_out")"
+    t_cache_str=$(format_tokens "$total_cache")
     t_dur_str=$(format_duration_ms "$total_dur")
-    printf "  ${BOLD}%-3s %-16s %-10s %8s %9s %5s %7s${RESET}\n" \
-        "" "Total" "" "$t_cost_str" "$t_inout_str" "$total_turns" "$t_dur_str"
+    printf "  ${BOLD}%-3s %-16s %-10s %8s %9s %6s %5s %7s${RESET}\n" \
+        "" "Total" "" "$t_cost_str" "$t_inout_str" "$t_cache_str" "$total_turns" "$t_dur_str"
 
     echo ""
 

--- a/test.sh
+++ b/test.sh
@@ -52,6 +52,8 @@ run_all_tests() {
             "2-agents-sonnet|2|claude-sonnet-4-6|"
             "2-agents-config|2|config-single|"
             "3-agents-mixed|3|config-mixed|"
+            "1-agent-effort-env|1|effort-env|"
+            "2-agents-effort-cfg|2|config-effort|"
             "2-agents-postprocess|2|config-pp|"
         )
 
@@ -141,6 +143,21 @@ PPPROMPT
                 > "$cfg"
             args+=(--config "$cfg")
             rm -f "$pp_prompt"
+            ;;
+        effort-env)
+            env_prefix=(SWARM_NUM_AGENTS="$num_agents"
+                        SWARM_EFFORT="medium")
+            ;;
+        config-effort)
+            local cfg
+            cfg=$(mktemp /tmp/${PROJECT}-inttest.XXXXXX.json)
+            jq -n --arg m1 "${SWARM_MODEL:-claude-opus-4-6}" \
+                  --arg m2 "claude-sonnet-4-6" \
+                '{prompt: "unused", agents: [
+                    {count: 1, model: $m1, effort: "high"},
+                    {count: 1, model: $m2, effort: "low"}
+                ]}' > "$cfg"
+            args+=(--config "$cfg")
             ;;
         "")
             env_prefix=(SWARM_NUM_AGENTS="$num_agents")

--- a/test_config.sh
+++ b/test_config.sh
@@ -35,10 +35,12 @@ parse_title()            { jq -r '.title // empty' "$1"; }
 parse_pp_prompt()        { jq -r '.post_process.prompt // empty' "$1"; }
 parse_pp_model()         { jq -r '.post_process.model // "claude-opus-4-6"' "$1"; }
 
-parse_agents_tsv() {
+parse_agents_cfg() {
     jq -r '.agents[] | range(.count) as $i |
-        [.model, (.base_url // ""), (.api_key // "")] | @tsv' "$1"
+        [.model, (.base_url // ""), (.api_key // ""), (.effort // "")] | join("|")' "$1"
 }
+
+parse_pp_effort() { jq -r '.post_process.effort // empty' "$1"; }
 
 # ============================================================
 echo "=== 1. Mixed-model config ==="
@@ -64,7 +66,7 @@ assert_eq "git name"  "test-agent"       "$(parse_git_name "$TMPDIR/mixed.json")
 assert_eq "git email" "test@example.com" "$(parse_git_email "$TMPDIR/mixed.json")"
 assert_eq "total agents" "6"             "$(parse_num_agents "$TMPDIR/mixed.json")"
 
-TSV=$(parse_agents_tsv "$TMPDIR/mixed.json")
+TSV=$(parse_agents_cfg "$TMPDIR/mixed.json")
 assert_eq "line count" "6" "$(echo "$TSV" | wc -l | tr -d ' ')"
 
 LINE1=$(echo "$TSV" | sed -n '1p')
@@ -72,20 +74,21 @@ LINE3=$(echo "$TSV" | sed -n '3p')
 LINE4=$(echo "$TSV" | sed -n '4p')
 LINE6=$(echo "$TSV" | sed -n '6p')
 
-IFS=$'\t' read -r m1 u1 k1 <<< "$LINE1"
+IFS='|' read -r m1 u1 k1 e1 <<< "$LINE1"
 assert_eq "agent 1 model"   "claude-opus-4-6" "$m1"
 assert_eq "agent 1 base_url" ""               "$u1"
 assert_eq "agent 1 api_key"  ""               "$k1"
+assert_eq "agent 1 effort"   ""               "$e1"
 
-IFS=$'\t' read -r m3 u3 k3 <<< "$LINE3"
+IFS='|' read -r m3 u3 k3 e3 <<< "$LINE3"
 assert_eq "agent 3 model" "claude-sonnet-4-5" "$m3"
 
-IFS=$'\t' read -r m4 u4 k4 <<< "$LINE4"
+IFS='|' read -r m4 u4 k4 e4 <<< "$LINE4"
 assert_eq "agent 4 model"    "openrouter/custom"                "$m4"
 assert_eq "agent 4 base_url" "https://openrouter.ai/api/v1"     "$u4"
 assert_eq "agent 4 api_key"  "sk-or-test"                       "$k4"
 
-IFS=$'\t' read -r m6 u6 k6 <<< "$LINE6"
+IFS='|' read -r m6 u6 k6 e6 <<< "$LINE6"
 assert_eq "agent 6 model"    "openrouter/custom"                "$m6"
 assert_eq "agent 6 base_url" "https://openrouter.ai/api/v1"     "$u6"
 assert_eq "agent 6 api_key"  "sk-or-test"                       "$k6"
@@ -110,7 +113,7 @@ assert_eq "git name default" "swarm-agent"           "$(parse_git_name "$TMPDIR/
 assert_eq "git email default" "agent@claude-swarm.local" "$(parse_git_email "$TMPDIR/minimal.json")"
 assert_eq "total agents" "2"                         "$(parse_num_agents "$TMPDIR/minimal.json")"
 
-TSV=$(parse_agents_tsv "$TMPDIR/minimal.json")
+TSV=$(parse_agents_cfg "$TMPDIR/minimal.json")
 assert_eq "all same model" "2" "$(echo "$TSV" | grep -c 'claude-sonnet-4-5')"
 
 # ============================================================
@@ -130,24 +133,26 @@ echo ""
 echo "=== 4. Env-var fallback (synthetic TSV) ==="
 
 CLAUDE_MODEL="claude-opus-4-6"
+EFFORT_LEVEL="medium"
 NUM_AGENTS=3
-: > "$TMPDIR/env-agents.tsv"
+: > "$TMPDIR/env-agents.cfg"
 for _i in $(seq 1 "$NUM_AGENTS"); do
-    printf '%s\t\t\n' "$CLAUDE_MODEL" >> "$TMPDIR/env-agents.tsv"
+    printf '%s|||%s\n' "$CLAUDE_MODEL" "$EFFORT_LEVEL" >> "$TMPDIR/env-agents.cfg"
 done
 
-assert_eq "line count" "3" "$(wc -l < "$TMPDIR/env-agents.tsv" | tr -d ' ')"
+assert_eq "line count" "3" "$(wc -l < "$TMPDIR/env-agents.cfg" | tr -d ' ')"
 
 AGENT_IDX=0
-while IFS=$'\t' read -r m u k; do
+while IFS='|' read -r m u k e; do
     AGENT_IDX=$((AGENT_IDX + 1))
-done < "$TMPDIR/env-agents.tsv"
+done < "$TMPDIR/env-agents.cfg"
 assert_eq "agents iterated" "3" "$AGENT_IDX"
 
-IFS=$'\t' read -r m u k < "$TMPDIR/env-agents.tsv"
+IFS='|' read -r m u k e < "$TMPDIR/env-agents.cfg"
 assert_eq "env model"    "claude-opus-4-6" "$m"
 assert_eq "env base_url" ""               "$u"
 assert_eq "env api_key"  ""               "$k"
+assert_eq "env effort"   "medium"         "$e"
 
 # ============================================================
 echo ""
@@ -161,7 +166,7 @@ cat > "$TMPDIR/single.json" <<'EOF'
 EOF
 
 assert_eq "total agents" "1" "$(parse_num_agents "$TMPDIR/single.json")"
-TSV=$(parse_agents_tsv "$TMPDIR/single.json")
+TSV=$(parse_agents_cfg "$TMPDIR/single.json")
 assert_eq "line count" "1" "$(echo "$TSV" | wc -l | tr -d ' ')"
 
 # ============================================================
@@ -179,8 +184,8 @@ cat > "$TMPDIR/allcustom.json" <<'EOF'
 EOF
 
 assert_eq "total agents" "3" "$(parse_num_agents "$TMPDIR/allcustom.json")"
-TSV=$(parse_agents_tsv "$TMPDIR/allcustom.json")
-assert_eq "no empty keys" "0" "$(echo "$TSV" | awk -F'\t' '$3 == ""' | wc -l | tr -d ' ')"
+TSV=$(parse_agents_cfg "$TMPDIR/allcustom.json")
+assert_eq "no empty keys" "0" "$(echo "$TSV" | awk -F'|' '$3 == ""' | wc -l | tr -d ' ')"
 
 # ============================================================
 echo ""
@@ -194,7 +199,7 @@ cat > "$TMPDIR/large.json" <<'EOF'
 EOF
 
 assert_eq "total agents" "20" "$(parse_num_agents "$TMPDIR/large.json")"
-TSV=$(parse_agents_tsv "$TMPDIR/large.json")
+TSV=$(parse_agents_cfg "$TMPDIR/large.json")
 assert_eq "line count" "20" "$(echo "$TSV" | wc -l | tr -d ' ')"
 
 # ============================================================
@@ -262,6 +267,55 @@ assert_eq "pp prompt"       "review.md"         "$(parse_pp_prompt "$TMPDIR/pp.j
 assert_eq "pp model"        "claude-sonnet-4-5"  "$(parse_pp_model "$TMPDIR/pp.json")"
 assert_eq "pp prompt absent" ""                  "$(parse_pp_prompt "$TMPDIR/inject_default.json")"
 assert_eq "pp model default" "claude-opus-4-6"   "$(parse_pp_model "$TMPDIR/inject_default.json")"
+
+# ============================================================
+echo ""
+echo "=== 12. effort field in agents ==="
+
+cat > "$TMPDIR/effort.json" <<'EOF'
+{
+  "prompt": "p.md",
+  "agents": [
+    { "count": 1, "model": "claude-opus-4-6", "effort": "high" },
+    { "count": 2, "model": "claude-sonnet-4-6", "effort": "medium" },
+    { "count": 1, "model": "claude-haiku-4-5" }
+  ]
+}
+EOF
+
+TSV=$(parse_agents_cfg "$TMPDIR/effort.json")
+assert_eq "effort line count" "4" "$(echo "$TSV" | wc -l | tr -d ' ')"
+
+LINE1=$(echo "$TSV" | sed -n '1p')
+LINE2=$(echo "$TSV" | sed -n '2p')
+LINE4=$(echo "$TSV" | sed -n '4p')
+
+IFS='|' read -r m1 u1 k1 e1 <<< "$LINE1"
+assert_eq "opus effort"   "high"   "$e1"
+
+IFS='|' read -r m2 u2 k2 e2 <<< "$LINE2"
+assert_eq "sonnet effort" "medium" "$e2"
+
+IFS='|' read -r m4 u4 k4 e4 <<< "$LINE4"
+assert_eq "haiku effort (empty)" "" "$e4"
+
+# ============================================================
+echo ""
+echo "=== 13. effort in post_process ==="
+
+cat > "$TMPDIR/pp_effort.json" <<'EOF'
+{
+  "prompt": "p.md",
+  "agents": [{ "count": 1, "model": "m" }],
+  "post_process": {
+    "prompt": "review.md",
+    "effort": "low"
+  }
+}
+EOF
+
+assert_eq "pp effort"        "low" "$(parse_pp_effort "$TMPDIR/pp_effort.json")"
+assert_eq "pp effort absent" ""    "$(parse_pp_effort "$TMPDIR/inject_default.json")"
 
 # ============================================================
 echo ""

--- a/test_costs.sh
+++ b/test_costs.sh
@@ -154,6 +154,28 @@ assert_eq "zero ms" "0" "$dur_s"
 
 # ============================================================
 echo ""
+echo "=== 8. format_duration (costs.sh) ==="
+
+format_duration() {
+    local s=$1
+    if [ "$s" -ge 3600 ]; then
+        printf '%dh %02dm' $((s / 3600)) $(((s % 3600) / 60))
+    elif [ "$s" -ge 60 ]; then
+        printf '%dm %02ds' $((s / 60)) $((s % 60))
+    else
+        printf '%ds' "$s"
+    fi
+}
+
+assert_eq "0 seconds"    "0s"      "$(format_duration 0)"
+assert_eq "45 seconds"   "45s"     "$(format_duration 45)"
+assert_eq "60 seconds"   "1m 00s"  "$(format_duration 60)"
+assert_eq "445 seconds"  "7m 25s"  "$(format_duration 445)"
+assert_eq "3600 seconds" "1h 00m"  "$(format_duration 3600)"
+assert_eq "7384 seconds" "2h 03m"  "$(format_duration 7384)"
+
+# ============================================================
+echo ""
 echo "==============================="
 echo "  ${PASS} passed, ${FAIL} failed"
 echo "==============================="


### PR DESCRIPTION
## Summary
- Support `effort` (`low`/`medium`/`high`) per agent in `swarm.json`
  and globally via `SWARM_EFFORT` env var. Passed to containers as
  `CLAUDE_CODE_EFFORT_LEVEL`. Dashboard and costs show it as `[L]`,
  `[M]`, or `[H]` next to the model name.
- Dashboard now shows a Cache column matching `costs.sh` output.
- `costs.sh` displays human-readable durations (`7m 25s` instead
  of `445s`) and includes effort in JSON output.
- `test.sh` gains `--unit` (unit tests only, no Docker/API key),
  `--help`, and two new integration cases (`1-agent-effort-env`,
  `2-agents-effort-cfg`). Smoke prompt adds a reasoning step to
  exercise adaptive thinking at different effort levels.
- Fix `local` used outside function in `costs.sh`.

## Test plan
- [x] `./test.sh --unit` passes (all unit test files)
- [x] `ANTHROPIC_API_KEY=... ./test.sh --all` passes full matrix
      (10 integration cases including effort variants)
- [x] `./dashboard.sh` shows `[L]`/`[M]`/`[H]` tags, cache column
      aligns correctly within 16-char Model column
- [x] `./costs.sh` shows human-readable durations and effort tags