### PR TITLE
Per-agent auth source selection with dashboard visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Based on the agent-team pattern from
 
 - Docker
 - bash, git, jq, bc
-- An Anthropic API key (or compatible endpoint)
+- An Anthropic API key, OAuth token, or compatible endpoint
 
 ## Setup
 
@@ -87,9 +87,10 @@ with `SWARM_CONFIG=/path/to/config.json`:
 }
 ```
 
-Agent groups without `api_key` use `ANTHROPIC_API_KEY` from
-the environment. Total agent count is the sum of all `count`
-fields. Requires `jq` on the host.
+Agent groups without `api_key` use `ANTHROPIC_API_KEY` (or
+`CLAUDE_CODE_OAUTH_TOKEN`) from the environment. Total agent
+count is the sum of all `count` fields. Requires `jq` on the
+host.
 
 The `effort` field controls Claude's adaptive reasoning depth
 (`low`, `medium`, `high`). Supported on Opus 4.6 and Sonnet 4.6.
@@ -104,7 +105,8 @@ disable this, e.g. when you want full control over the prompt.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| ANTHROPIC_API_KEY | (required) | API key. |
+| ANTHROPIC_API_KEY | | API key (required unless CLAUDE_CODE_OAUTH_TOKEN is set). |
+| CLAUDE_CODE_OAUTH_TOKEN | | OAuth token from `claude setup-token`. Uses your subscription instead of API credits. |
 | SWARM_PROMPT | (required) | Prompt file path. |
 | SWARM_CONFIG | | Config file path. |
 | SWARM_SETUP | | Setup script path. |
@@ -135,6 +137,26 @@ SWARM_PROMPT="tasks/task.md" \
 ```
 
 The model name is passed through as-is to `claude --model`.
+
+### Using a Claude subscription (Pro/Max/Teams/Enterprise)
+
+Instead of an API key you can use your Claude subscription.
+Generate an OAuth token on the host:
+
+    claude setup-token
+
+Then launch with the token instead of an API key:
+
+```bash
+CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat01-..." \
+SWARM_PROMPT="tasks/task.md" \
+./launch.sh start
+```
+
+Both `ANTHROPIC_API_KEY` and `CLAUDE_CODE_OAUTH_TOKEN` can be
+set simultaneously; the `claude` CLI decides which to use.
+Per-agent `api_key` in `swarm.json` still works as before for
+the API-key flow.
 
 ## Commands and usage
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ with `SWARM_CONFIG=/path/to/config.json`:
   "setup": "scripts/setup.sh",
   "max_idle": 3,
   "agents": [
-    { "count": 2, "model": "claude-opus-4-6", "effort": "high" },
+    { "count": 2, "model": "claude-opus-4-6", "effort": "high", "auth": "apikey" },
+    { "count": 1, "model": "claude-opus-4-6", "auth": "oauth" },
     { "count": 1, "model": "claude-sonnet-4-6", "effort": "medium" },
     {
       "count": 3,
@@ -95,6 +96,14 @@ host.
 The `effort` field controls Claude's adaptive reasoning depth
 (`low`, `medium`, `high`). Supported on Opus 4.6 and Sonnet 4.6.
 Omit it to use the model's default (`high`).
+
+The `auth` field selects which credential is passed into the
+container: `"apikey"` uses only `ANTHROPIC_API_KEY`, `"oauth"`
+uses only `CLAUDE_CODE_OAUTH_TOKEN` (subscription mode), and
+omitting it passes both (the CLI decides). Groups with a custom
+`api_key`/`base_url` ignore `auth` -- their own key is always
+used. The dashboard shows the active auth source per agent
+(e.g. `{oauth}`, `{apikey}`).
 
 By default, agents receive git coordination rules
 (commit/push/rebase workflow) appended to their system

--- a/launch.sh
+++ b/launch.sh
@@ -43,8 +43,8 @@ else
 fi
 
 cmd_start() {
-    if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -z "$CONFIG_FILE" ]; then
-        echo "ERROR: ANTHROPIC_API_KEY is not set." >&2
+    if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] && [ -z "$CONFIG_FILE" ]; then
+        echo "ERROR: ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN must be set." >&2
         exit 1
     fi
 
@@ -150,6 +150,8 @@ cmd_start() {
         fi
         [ -n "${ANTHROPIC_AUTH_TOKEN:-}" ] \
             && EXTRA_ENV+=(-e "ANTHROPIC_AUTH_TOKEN=${ANTHROPIC_AUTH_TOKEN}")
+        [ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] \
+            && EXTRA_ENV+=(-e "CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN}")
         local eff="${agent_effort:-${EFFORT_LEVEL:-}}"
         [ -n "$eff" ] \
             && EXTRA_ENV+=(-e "CLAUDE_CODE_EFFORT_LEVEL=${eff}")
@@ -318,6 +320,8 @@ cmd_post_process() {
     fi
     [ -n "${ANTHROPIC_AUTH_TOKEN:-}" ] \
         && EXTRA_ENV+=(-e "ANTHROPIC_AUTH_TOKEN=${ANTHROPIC_AUTH_TOKEN}")
+    [ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] \
+        && EXTRA_ENV+=(-e "CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN}")
     [ -n "$pp_effort" ] \
         && EXTRA_ENV+=(-e "CLAUDE_CODE_EFFORT_LEVEL=${pp_effort}")
 

--- a/launch.sh
+++ b/launch.sh
@@ -109,17 +109,17 @@ cmd_start() {
         echo "-v ${mirror}:/mirrors/${name}:ro"
     done > /tmp/${PROJECT}-mirror-vols.txt
 
-    # Build per-agent config (model|base_url|api_key|effort per line).
+    # Build per-agent config (model|base_url|api_key|effort|auth per line).
     # Uses pipe delimiter because bash IFS=$'\t' collapses consecutive tabs.
     AGENTS_CFG="/tmp/${PROJECT}-agents.cfg"
     if [ -n "$CONFIG_FILE" ]; then
         jq -r '.agents[] | range(.count) as $i |
-            [.model, (.base_url // ""), (.api_key // ""), (.effort // "")] | join("|")' \
+            [.model, (.base_url // ""), (.api_key // ""), (.effort // ""), (.auth // "")] | join("|")' \
             "$CONFIG_FILE" > "$AGENTS_CFG"
     else
         : > "$AGENTS_CFG"
         for _i in $(seq 1 "$NUM_AGENTS"); do
-            printf '%s|||%s\n' "$CLAUDE_MODEL" "${EFFORT_LEVEL:-}" >> "$AGENTS_CFG"
+            printf '%s|||%s|\n' "$CLAUDE_MODEL" "${EFFORT_LEVEL:-}" >> "$AGENTS_CFG"
         done
     fi
 
@@ -131,7 +131,7 @@ cmd_start() {
     done < /tmp/${PROJECT}-mirror-vols.txt
 
     AGENT_IDX=0
-    while IFS='|' read -r agent_model agent_base_url agent_api_key agent_effort; do
+    while IFS='|' read -r agent_model agent_base_url agent_api_key agent_effort agent_auth; do
         AGENT_IDX=$((AGENT_IDX + 1))
         NAME="${IMAGE_NAME}-${AGENT_IDX}"
         docker rm -f "$NAME" 2>/dev/null || true
@@ -141,7 +141,7 @@ cmd_start() {
         short_model="${short_model//\//-}"
         local agent_git_name="${GIT_USER_NAME} [${short_model}]"
 
-        echo "--- Launching ${NAME} (${agent_model}${agent_effort:+ effort=${agent_effort}}) ---"
+        echo "--- Launching ${NAME} (${agent_model}${agent_effort:+ effort=${agent_effort}}${agent_auth:+ auth=${agent_auth}}) ---"
         EXTRA_ENV=()
         if [ -n "$agent_base_url" ]; then
             EXTRA_ENV+=(-e "ANTHROPIC_BASE_URL=${agent_base_url}")
@@ -150,8 +150,30 @@ cmd_start() {
         fi
         [ -n "${ANTHROPIC_AUTH_TOKEN:-}" ] \
             && EXTRA_ENV+=(-e "ANTHROPIC_AUTH_TOKEN=${ANTHROPIC_AUTH_TOKEN}")
-        [ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] \
-            && EXTRA_ENV+=(-e "CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN}")
+
+        # Auto-tag agents with a custom api_key as "apikey" for the dashboard.
+        if [ -z "$agent_auth" ] && [ -n "$agent_api_key" ]; then
+            agent_auth="apikey"
+        fi
+
+        # Per-agent auth source: "oauth" = subscription only,
+        # "apikey" = API key only, "" = pass both (CLI decides).
+        local resolved_api_key
+        case "${agent_auth}" in
+            oauth)
+                resolved_api_key=""
+                EXTRA_ENV+=(-e "CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN:-}")
+                ;;
+            apikey)
+                resolved_api_key="${agent_api_key:-${ANTHROPIC_API_KEY:-}}"
+                ;;
+            *)
+                resolved_api_key="${agent_api_key:-${ANTHROPIC_API_KEY:-}}"
+                [ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] \
+                    && EXTRA_ENV+=(-e "CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN}")
+                ;;
+        esac
+
         local eff="${agent_effort:-${EFFORT_LEVEL:-}}"
         [ -n "$eff" ] \
             && EXTRA_ENV+=(-e "CLAUDE_CODE_EFFORT_LEVEL=${eff}")
@@ -160,7 +182,7 @@ cmd_start() {
             --name "$NAME" \
             -v "${BARE_REPO}:/upstream:rw" \
             "${MIRROR_ARGS[@]+"${MIRROR_ARGS[@]}"}" \
-            -e "ANTHROPIC_API_KEY=${agent_api_key:-${ANTHROPIC_API_KEY:-}}" \
+            -e "ANTHROPIC_API_KEY=${resolved_api_key}" \
             "${EXTRA_ENV[@]+"${EXTRA_ENV[@]}"}" \
             -e "CLAUDE_MODEL=${agent_model}" \
             -e "AGENT_PROMPT=${AGENT_PROMPT}" \
@@ -170,6 +192,7 @@ cmd_start() {
             -e "GIT_USER_EMAIL=${GIT_USER_EMAIL}" \
             -e "INJECT_GIT_RULES=${INJECT_GIT_RULES}" \
             -e "AGENT_ID=${AGENT_IDX}" \
+            -e "SWARM_AUTH_MODE=${agent_auth}" \
             "$IMAGE_NAME"
     done < "$AGENTS_CFG"
 
@@ -276,12 +299,13 @@ cmd_post_process() {
         exit 1
     fi
 
-    local pp_prompt pp_model pp_base_url pp_api_key pp_effort
+    local pp_prompt pp_model pp_base_url pp_api_key pp_effort pp_auth
     pp_prompt=$(jq -r '.post_process.prompt // empty' "$CONFIG_FILE")
     pp_model=$(jq -r '.post_process.model // "claude-opus-4-6"' "$CONFIG_FILE")
     pp_base_url=$(jq -r '.post_process.base_url // empty' "$CONFIG_FILE")
     pp_api_key=$(jq -r '.post_process.api_key // empty' "$CONFIG_FILE")
     pp_effort=$(jq -r '.post_process.effort // empty' "$CONFIG_FILE")
+    pp_auth=$(jq -r '.post_process.auth // empty' "$CONFIG_FILE")
 
     if [ -z "$pp_prompt" ]; then
         echo "ERROR: post_process.prompt is not set in ${CONFIG_FILE}." >&2
@@ -312,6 +336,10 @@ cmd_post_process() {
     done < /tmp/${PROJECT}-pp-vols.txt
     rm -f /tmp/${PROJECT}-pp-vols.txt
 
+    if [ -z "$pp_auth" ] && [ -n "$pp_api_key" ]; then
+        pp_auth="apikey"
+    fi
+
     local EXTRA_ENV=()
     if [ -n "$pp_base_url" ]; then
         EXTRA_ENV+=(-e "ANTHROPIC_BASE_URL=${pp_base_url}")
@@ -320,8 +348,23 @@ cmd_post_process() {
     fi
     [ -n "${ANTHROPIC_AUTH_TOKEN:-}" ] \
         && EXTRA_ENV+=(-e "ANTHROPIC_AUTH_TOKEN=${ANTHROPIC_AUTH_TOKEN}")
-    [ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] \
-        && EXTRA_ENV+=(-e "CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN}")
+
+    local pp_resolved_api_key
+    case "${pp_auth}" in
+        oauth)
+            pp_resolved_api_key=""
+            EXTRA_ENV+=(-e "CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN:-}")
+            ;;
+        apikey)
+            pp_resolved_api_key="${pp_api_key:-${ANTHROPIC_API_KEY:-}}"
+            ;;
+        *)
+            pp_resolved_api_key="${pp_api_key:-${ANTHROPIC_API_KEY:-}}"
+            [ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] \
+                && EXTRA_ENV+=(-e "CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN}")
+            ;;
+    esac
+
     [ -n "$pp_effort" ] \
         && EXTRA_ENV+=(-e "CLAUDE_CODE_EFFORT_LEVEL=${pp_effort}")
 
@@ -330,7 +373,7 @@ cmd_post_process() {
         --name "$NAME" \
         -v "${BARE_REPO}:/upstream:rw" \
         "${MIRROR_ARGS[@]+"${MIRROR_ARGS[@]}"}" \
-        -e "ANTHROPIC_API_KEY=${pp_api_key:-${ANTHROPIC_API_KEY:-}}" \
+        -e "ANTHROPIC_API_KEY=${pp_resolved_api_key}" \
         "${EXTRA_ENV[@]+"${EXTRA_ENV[@]}"}" \
         -e "CLAUDE_MODEL=${pp_model}" \
         -e "AGENT_PROMPT=${pp_prompt}" \
@@ -340,6 +383,7 @@ cmd_post_process() {
         -e "GIT_USER_EMAIL=${GIT_USER_EMAIL}" \
         -e "INJECT_GIT_RULES=${INJECT_GIT_RULES}" \
         -e "AGENT_ID=post" \
+        -e "SWARM_AUTH_MODE=${pp_auth}" \
         "$IMAGE_NAME"
 
     echo "Post-processing agent launched: ${NAME}"

--- a/setup.sh
+++ b/setup.sh
@@ -136,6 +136,16 @@ while true; do
         if [ -n "$GROUP_KEY" ]; then
             AGENT_OBJ+=", \"api_key\": \"${GROUP_KEY}\""
         fi
+    else
+        echo "  Auth source for this group:"
+        echo "    1) auto (pass both API key + OAuth token; CLI decides)"
+        echo "    2) apikey (API key only)"
+        echo "    3) oauth (subscription/OAuth token only)"
+        AUTH_CHOICE=$(input "Choice [1/2/3]" "1")
+        case "$AUTH_CHOICE" in
+            2) AGENT_OBJ+=", \"auth\": \"apikey\"" ;;
+            3) AGENT_OBJ+=", \"auth\": \"oauth\"" ;;
+        esac
     fi
 
     AGENT_OBJ+="}"

--- a/setup.sh
+++ b/setup.sh
@@ -69,18 +69,37 @@ echo "claude-swarm setup wizard"
 echo "========================="
 echo ""
 
-# 1. API key.
+# 1. Authentication (API key or OAuth token).
 API_KEY="${ANTHROPIC_API_KEY:-}"
-if [ -n "$API_KEY" ]; then
+OAUTH_TOKEN="${CLAUDE_CODE_OAUTH_TOKEN:-}"
+AUTH_MODE=""
+
+if [ -n "$OAUTH_TOKEN" ]; then
+    AUTH_MODE="oauth"
+    echo "CLAUDE_CODE_OAUTH_TOKEN detected in environment (${#OAUTH_TOKEN} chars)."
+elif [ -n "$API_KEY" ]; then
+    AUTH_MODE="apikey"
     echo "ANTHROPIC_API_KEY detected in environment (${#API_KEY} chars)."
 else
-    API_KEY=$(password "Enter your ANTHROPIC_API_KEY")
-    if [ -z "$API_KEY" ]; then
-        echo "ERROR: API key is required." >&2
-        exit 1
+    if yesno "Use an OAuth token instead of an API key? (for Pro/Max/Teams/Enterprise)"; then
+        AUTH_MODE="oauth"
+        OAUTH_TOKEN=$(password "Enter your CLAUDE_CODE_OAUTH_TOKEN (from 'claude setup-token')")
+        if [ -z "$OAUTH_TOKEN" ]; then
+            echo "ERROR: OAuth token is required." >&2
+            exit 1
+        fi
+        echo ""
+        echo "Tip: export CLAUDE_CODE_OAUTH_TOKEN before running launch.sh."
+    else
+        AUTH_MODE="apikey"
+        API_KEY=$(password "Enter your ANTHROPIC_API_KEY")
+        if [ -z "$API_KEY" ]; then
+            echo "ERROR: API key is required." >&2
+            exit 1
+        fi
+        echo ""
+        echo "Tip: export ANTHROPIC_API_KEY before running launch.sh."
     fi
-    echo ""
-    echo "Tip: export ANTHROPIC_API_KEY before running launch.sh."
 fi
 
 # 2. Prompt file.
@@ -194,7 +213,11 @@ if yesno "Write ${OUTPUT}?"; then
     echo "Config written to ${OUTPUT}"
     echo ""
     if yesno "Launch swarm now?"; then
-        export ANTHROPIC_API_KEY="$API_KEY"
+        if [ "$AUTH_MODE" = "oauth" ]; then
+            export CLAUDE_CODE_OAUTH_TOKEN="$OAUTH_TOKEN"
+        else
+            export ANTHROPIC_API_KEY="$API_KEY"
+        fi
         "$SWARM_DIR/launch.sh" start
     fi
 else

--- a/test_launch.sh
+++ b/test_launch.sh
@@ -41,7 +41,28 @@ parse_pp_effort()   { jq -r '.post_process.effort // empty' "$1"; }
 
 parse_agents_cfg() {
     jq -r '.agents[] | range(.count) as $i |
-        [.model, (.base_url // ""), (.api_key // ""), (.effort // "")] | join("|")' "$1"
+        [.model, (.base_url // ""), (.api_key // ""), (.effort // ""), (.auth // "")] | join("|")' "$1"
+}
+
+# Mirrors the per-agent credential selection in launch.sh.
+resolve_agent_creds() {
+    local agent_auth="$1" agent_api_key="$2" global_api_key="$3" global_oauth="$4"
+    local resolved_key="" oauth_env=""
+    case "${agent_auth}" in
+        oauth)
+            resolved_key=""
+            oauth_env="CLAUDE_CODE_OAUTH_TOKEN=${global_oauth}"
+            ;;
+        apikey)
+            resolved_key="${agent_api_key:-${global_api_key}}"
+            oauth_env=""
+            ;;
+        *)
+            resolved_key="${agent_api_key:-${global_api_key}}"
+            [ -n "$global_oauth" ] && oauth_env="CLAUDE_CODE_OAUTH_TOKEN=${global_oauth}"
+            ;;
+    esac
+    echo "${resolved_key}|${oauth_env}"
 }
 
 # Mirrors the validation guard in cmd_start().
@@ -82,16 +103,17 @@ EFFORT_LEVEL="medium"
 NUM_AGENTS=3
 : > "$TMPDIR/env-agents.cfg"
 for _i in $(seq 1 "$NUM_AGENTS"); do
-    printf '%s|||%s\n' "$CLAUDE_MODEL" "$EFFORT_LEVEL" >> "$TMPDIR/env-agents.cfg"
+    printf '%s|||%s|\n' "$CLAUDE_MODEL" "$EFFORT_LEVEL" >> "$TMPDIR/env-agents.cfg"
 done
 
 assert_eq "line count" "3" "$(wc -l < "$TMPDIR/env-agents.cfg" | tr -d ' ')"
 
-IFS='|' read -r m u k e < "$TMPDIR/env-agents.cfg"
+IFS='|' read -r m u k e a < "$TMPDIR/env-agents.cfg"
 assert_eq "model"    "claude-opus-4-6" "$m"
 assert_eq "base_url" ""               "$u"
 assert_eq "api_key"  ""               "$k"
 assert_eq "effort"   "medium"         "$e"
+assert_eq "auth"     ""               "$a"
 
 # ============================================================
 echo ""
@@ -191,13 +213,13 @@ LINE1=$(echo "$CFG" | sed -n '1p')
 LINE2=$(echo "$CFG" | sed -n '2p')
 LINE4=$(echo "$CFG" | sed -n '4p')
 
-IFS='|' read -r m1 u1 k1 e1 <<< "$LINE1"
+IFS='|' read -r m1 u1 k1 e1 a1 <<< "$LINE1"
 assert_eq "opus effort"  "high"   "$e1"
 
-IFS='|' read -r m2 u2 k2 e2 <<< "$LINE2"
+IFS='|' read -r m2 u2 k2 e2 a2 <<< "$LINE2"
 assert_eq "sonnet effort" "medium" "$e2"
 
-IFS='|' read -r m4 u4 k4 e4 <<< "$LINE4"
+IFS='|' read -r m4 u4 k4 e4 a4 <<< "$LINE4"
 assert_eq "haiku effort (empty)" "" "$e4"
 
 # ============================================================
@@ -225,9 +247,9 @@ echo "=== 8. Effort env var fallback (no effort set) ==="
 
 EFFORT_LEVEL=""
 : > "$TMPDIR/env-no-effort.cfg"
-printf '%s|||%s\n' "claude-opus-4-6" "$EFFORT_LEVEL" >> "$TMPDIR/env-no-effort.cfg"
+printf '%s|||%s|\n' "claude-opus-4-6" "$EFFORT_LEVEL" >> "$TMPDIR/env-no-effort.cfg"
 
-IFS='|' read -r m u k e < "$TMPDIR/env-no-effort.cfg"
+IFS='|' read -r m u k e a < "$TMPDIR/env-no-effort.cfg"
 assert_eq "no effort" "" "$e"
 
 # ============================================================
@@ -249,6 +271,65 @@ assert_eq "oauth env set" \
     "-e CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-test" \
     "$(build_oauth_extra_env "sk-ant-oat01-test")"
 assert_eq "oauth env empty" "" "$(build_oauth_extra_env "")"
+
+# ============================================================
+echo ""
+echo "=== 11. Per-agent auth field in TSV ==="
+
+cat > "$TMPDIR/auth_mixed.json" <<'EOF'
+{
+  "prompt": "p.md",
+  "agents": [
+    { "count": 1, "model": "claude-opus-4-6", "auth": "apikey" },
+    { "count": 1, "model": "claude-opus-4-6", "auth": "oauth" },
+    { "count": 1, "model": "MiniMax-M2.5", "base_url": "https://api.minimax.io", "api_key": "sk-mm" }
+  ]
+}
+EOF
+
+CFG=$(parse_agents_cfg "$TMPDIR/auth_mixed.json")
+LINE1=$(echo "$CFG" | sed -n '1p')
+LINE2=$(echo "$CFG" | sed -n '2p')
+LINE3=$(echo "$CFG" | sed -n '3p')
+
+IFS='|' read -r m1 u1 k1 e1 a1 <<< "$LINE1"
+assert_eq "auth apikey"  "apikey"  "$a1"
+assert_eq "auth apikey model" "claude-opus-4-6" "$m1"
+
+IFS='|' read -r m2 u2 k2 e2 a2 <<< "$LINE2"
+assert_eq "auth oauth"   "oauth"   "$a2"
+
+IFS='|' read -r m3 u3 k3 e3 a3 <<< "$LINE3"
+assert_eq "auth custom (empty)" "" "$a3"
+assert_eq "auth custom key" "sk-mm" "$k3"
+
+# ============================================================
+echo ""
+echo "=== 12. Per-agent credential resolution ==="
+
+RESULT=$(resolve_agent_creds "oauth" "" "sk-global" "sk-oat-tok")
+IFS='|' read -r rk re <<< "$RESULT"
+assert_eq "oauth: api_key cleared"  ""  "$rk"
+assert_eq "oauth: token passed" "CLAUDE_CODE_OAUTH_TOKEN=sk-oat-tok" "$re"
+
+RESULT=$(resolve_agent_creds "apikey" "" "sk-global" "sk-oat-tok")
+IFS='|' read -r rk re <<< "$RESULT"
+assert_eq "apikey: api_key set"   "sk-global" "$rk"
+assert_eq "apikey: no token"      ""           "$re"
+
+RESULT=$(resolve_agent_creds "" "" "sk-global" "sk-oat-tok")
+IFS='|' read -r rk re <<< "$RESULT"
+assert_eq "default: api_key set"  "sk-global" "$rk"
+assert_eq "default: token passed" "CLAUDE_CODE_OAUTH_TOKEN=sk-oat-tok" "$re"
+
+RESULT=$(resolve_agent_creds "" "sk-agent" "sk-global" "sk-oat-tok")
+IFS='|' read -r rk re <<< "$RESULT"
+assert_eq "custom key overrides"  "sk-agent" "$rk"
+
+RESULT=$(resolve_agent_creds "" "" "sk-global" "")
+IFS='|' read -r rk re <<< "$RESULT"
+assert_eq "no oauth: api_key set" "sk-global" "$rk"
+assert_eq "no oauth: no token"    ""           "$re"
 
 # ============================================================
 echo ""

--- a/test_setup.sh
+++ b/test_setup.sh
@@ -22,7 +22,7 @@ assert_eq() {
     fi
 }
 
-# --- Helpers: same jq pipeline used in setup.sh ---
+# --- Helpers: same jq pipeline and auth logic used in setup.sh ---
 
 build_config() {
     local prompt="$1" setup="$2" max_idle="$3"
@@ -66,6 +66,18 @@ build_agents_json() {
         shift 2
     done
     echo "$result"
+}
+
+# Mirrors setup.sh auth mode detection logic.
+detect_auth_mode() {
+    local api_key="$1" oauth_token="$2"
+    if [ -n "$oauth_token" ]; then
+        echo "oauth"
+    elif [ -n "$api_key" ]; then
+        echo "apikey"
+    else
+        echo "prompt"
+    fi
 }
 
 # ============================================================
@@ -140,6 +152,30 @@ CONFIG=$(build_config "p.md" "" 3 "sa" "a@a" "$AGENTS")
 
 assert_eq "base_url" "https://example.com" "$(echo "$CONFIG" | jq -r '.agents[0].base_url')"
 assert_eq "api_key"  "sk-test"             "$(echo "$CONFIG" | jq -r '.agents[0].api_key')"
+
+# ============================================================
+echo ""
+echo "=== 7. OAuth auth mode detection ==="
+
+assert_eq "oauth token present"   "oauth"   "$(detect_auth_mode "" "sk-ant-oat01-tok")"
+assert_eq "api key present"       "apikey"  "$(detect_auth_mode "sk-key" "")"
+assert_eq "oauth takes precedence" "oauth"  "$(detect_auth_mode "sk-key" "sk-ant-oat01-tok")"
+assert_eq "neither set"           "prompt"  "$(detect_auth_mode "" "")"
+
+# ============================================================
+echo ""
+echo "=== 8. Config valid without API key (OAuth-only) ==="
+
+AGENTS=$(build_agents_json 3 "claude-opus-4-6")
+CONFIG=$(build_config "task.md" "" 3 "swarm-agent" "agent@claude-swarm.local" "$AGENTS")
+
+echo "$CONFIG" > "$TMPDIR/oauth-config.json"
+assert_eq "valid JSON (oauth)" "true" \
+    "$(jq empty "$TMPDIR/oauth-config.json" 2>/dev/null && echo true || echo false)"
+assert_eq "no api_key in config" "null" \
+    "$(echo "$CONFIG" | jq -r '.agents[0].api_key // "null"')"
+assert_eq "agent count (oauth)" "3" \
+    "$(echo "$CONFIG" | jq '[.agents[].count] | add')"
 
 # ============================================================
 echo ""

--- a/test_setup.sh
+++ b/test_setup.sh
@@ -179,6 +179,25 @@ assert_eq "agent count (oauth)" "3" \
 
 # ============================================================
 echo ""
+echo "=== 9. Auth field in agent objects ==="
+
+AGENT_APIKEY='{"count": 1, "model": "claude-opus-4-6", "auth": "apikey"}'
+AGENT_OAUTH='{"count": 1, "model": "claude-opus-4-6", "auth": "oauth"}'
+AGENT_DEFAULT='{"count": 1, "model": "claude-opus-4-6"}'
+AGENTS=$(echo "[]" | jq --argjson a1 "$AGENT_APIKEY" --argjson a2 "$AGENT_OAUTH" --argjson a3 "$AGENT_DEFAULT" \
+    '. + [$a1, $a2, $a3]')
+CONFIG=$(build_config "p.md" "" 3 "sa" "a@a" "$AGENTS")
+
+assert_eq "auth apikey" "apikey" "$(echo "$CONFIG" | jq -r '.agents[0].auth')"
+assert_eq "auth oauth"  "oauth"  "$(echo "$CONFIG" | jq -r '.agents[1].auth')"
+assert_eq "auth absent" "null"   "$(echo "$CONFIG" | jq -r '.agents[2].auth // "null"')"
+
+echo "$CONFIG" > "$TMPDIR/auth-config.json"
+assert_eq "auth config valid" "true" \
+    "$(jq empty "$TMPDIR/auth-config.json" 2>/dev/null && echo true || echo false)"
+
+# ============================================================
+echo ""
 echo "==============================="
 echo "  ${PASS} passed, ${FAIL} failed"
 echo "==============================="


### PR DESCRIPTION
## Summary

- Add optional `"auth"` field (`oauth`/`apikey`/auto) to agent groups in `swarm.json` to control which credentials are injected per container
- Add dedicated Auth column to the dashboard with auto-detection from container env vars when not explicitly configured
- Add mixed-auth integration test case, fix test runner pass count extraction, and show skip notes when tokens are missing in `--all` summary
- Add auth source prompt to the setup wizard and document the field in README

## How it works

Each agent group can specify `"auth": "oauth"` (subscription only), `"auth": "apikey"` (API key only), or omit it (pass both, CLI decides). Agents with a custom `api_key`/`base_url` (third-party providers) are auto-tagged as `apikey`. The dashboard reads `SWARM_AUTH_MODE` from each container and displays it in an aligned column:

```
  #   Model            Auth   Status         Cost    In/Out  Cache Turns    Time
  1   opus-4-6         apikey running       $0.43     24/3k   362k    23  1m 20s
  2   opus-4-6         oauth  running       $0.30     18/2k   287k    16     57s
  3   MiniMax-M2.5     apikey running       $0.13   770/800    92k     6     48s
```

## Test plan

- [x] All 7 unit test suites pass (260 assertions, 0 failures)
- [x] Mixed-auth integration test (Opus apikey + Opus oauth + MiniMax) verified manually
- [x] Dashboard Auth column renders correctly and auto-detects for legacy containers
- [x] `--all` summary shows SKIP notes when `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` not set