### PR TITLE
Add --help flag to all scripts

### DIFF
--- a/costs.sh
+++ b/costs.sh
@@ -9,6 +9,22 @@ PROJECT="$(basename "$REPO_ROOT")"
 IMAGE_NAME="${PROJECT}-agent"
 JSON_MODE=false
 
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+    cat <<HELP
+Usage: $0 [--json]
+
+Print cost and usage summary for all swarm agents.
+
+Options:
+  --json   Output as JSON instead of a formatted table.
+  -h, --help  Show this help message.
+
+Reads stats from running or stopped agent containers via
+docker cp. Requires Docker access.
+HELP
+    exit 0
+fi
+
 if [ "${1:-}" = "--json" ]; then
     JSON_MODE=true
 fi

--- a/dashboard.sh
+++ b/dashboard.sh
@@ -11,6 +11,28 @@ BARE_REPO="/tmp/${PROJECT}-upstream.git"
 IMAGE_NAME="${PROJECT}-agent"
 START_TIME=$(date +%s)
 
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+    cat <<HELP
+Usage: $0
+
+Always-on TUI dashboard for claude-swarm.
+Refreshes every 2 seconds. Shows per-agent model, auth source,
+status, cost, token usage, cache hits, turns, and duration.
+
+Keybindings:
+  q           Quit the dashboard.
+  1-9         Tail logs for agent N.
+  h           Harvest agent results into current branch.
+  s           Stop all agents.
+  p           Run post-processing agent.
+
+Environment:
+  SWARM_TITLE    Dashboard title override.
+  SWARM_CONFIG   Path to swarm.json (auto-detected from repo root).
+HELP
+    exit 0
+fi
+
 # Save user's explicit env var so it takes priority over state file.
 USER_TITLE="${SWARM_TITLE:-}"
 

--- a/harness.sh
+++ b/harness.sh
@@ -3,6 +3,30 @@ set -euo pipefail
 
 # Container entrypoint: clone, setup, loop claude sessions.
 
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+    cat <<HELP
+Usage: $0
+
+Container entrypoint for claude-swarm agents. Not intended to
+be run directly -- launched automatically inside Docker by
+launch.sh.
+
+Clones the bare repo, runs optional setup, then loops claude
+sessions until the agent is idle for MAX_IDLE cycles.
+
+Required environment:
+  AGENT_PROMPT   Path to prompt file (relative to repo root).
+  CLAUDE_MODEL   Model to use for claude sessions.
+
+Optional environment:
+  AGENT_ID       Agent identifier (default: unnamed).
+  AGENT_SETUP    Setup script to run before first session.
+  MAX_IDLE       Idle sessions before exit (default: 3).
+  INJECT_GIT_RULES  Inject git coordination rules (default: true).
+HELP
+    exit 0
+fi
+
 AGENT_ID="${AGENT_ID:-unnamed}"
 CLAUDE_MODEL="${CLAUDE_MODEL:-claude-opus-4-6}"
 AGENT_PROMPT="${AGENT_PROMPT:?AGENT_PROMPT is required.}"

--- a/harvest.sh
+++ b/harvest.sh
@@ -12,6 +12,21 @@ DRY_RUN=false
 
 for arg in "$@"; do
     case "$arg" in
+        -h|--help)
+            cat <<HELP
+Usage: $0 [--dry]
+
+Fetch agent-work from the bare repo and merge into the current branch.
+
+Options:
+  --dry        Show what would be merged without actually merging.
+  -h, --help   Show this help message.
+
+The bare repo is expected at /tmp/<project>-upstream.git,
+created by launch.sh when starting agents.
+HELP
+            exit 0
+            ;;
         --dry)  DRY_RUN=true ;;
     esac
 done

--- a/launch.sh
+++ b/launch.sh
@@ -407,7 +407,36 @@ cmd_post_process() {
     "$SWARM_DIR/harvest.sh"
 }
 
+cmd_help() {
+    cat <<HELP
+Usage: $0 COMMAND [OPTIONS]
+
+Orchestrate Claude Code agents in Docker containers.
+
+Commands:
+  start [--dashboard]  Build image, create bare repo, launch agents.
+                       With --dashboard, open the TUI after launch.
+  stop                 Stop all running agent containers.
+  logs N               Tail logs for agent N (default: 1).
+  status               Show running/stopped state for each agent.
+  wait                 Block until all agents exit, then harvest.
+  post-process         Run the post-processing agent from the config.
+
+Environment:
+  ANTHROPIC_API_KEY         API key (required unless OAuth token or config).
+  CLAUDE_CODE_OAUTH_TOKEN   OAuth token for subscription-based auth.
+  SWARM_CONFIG              Path to swarm.json config file.
+  SWARM_PROMPT              Prompt file path (env-var mode).
+  SWARM_MODEL               Model name (default: claude-opus-4-6).
+  SWARM_NUM_AGENTS          Agent count (default: 3).
+  SWARM_MAX_IDLE            Idle sessions before exit (default: 3).
+  SWARM_EFFORT              Reasoning effort: low, medium, high.
+  SWARM_TITLE               Dashboard title override.
+HELP
+}
+
 case "${1:-start}" in
+    -h|--help)     cmd_help ;;
     start)
         cmd_start
         if [ "${2:-}" = "--dashboard" ]; then
@@ -421,6 +450,7 @@ case "${1:-start}" in
     post-process)  cmd_post_process ;;
     *)
         echo "Usage: $0 {start|stop|logs N|status|wait|post-process}" >&2
+        echo "Try '$0 --help' for more information." >&2
         exit 1
         ;;
 esac

--- a/progress.sh
+++ b/progress.sh
@@ -3,6 +3,17 @@ set -euo pipefail
 
 # Show what agents have pushed to the bare repo.
 
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+    cat <<HELP
+Usage: $0
+
+Show what agents have pushed to the bare repo.
+Clones the bare repo to a temp directory, displays recent
+commits on agent-work, and lists running agent containers.
+HELP
+    exit 0
+fi
+
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 PROJECT="$(basename "$REPO_ROOT")"
 BARE_REPO="/tmp/${PROJECT}-upstream.git"

--- a/setup.sh
+++ b/setup.sh
@@ -10,6 +10,27 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 OUTPUT="$REPO_ROOT/swarm.json"
 USE_WHIPTAIL=false
 
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+    cat <<HELP
+Usage: $0
+
+Interactive setup wizard for claude-swarm.
+Generates a swarm.json config file in the repo root.
+
+Walks through: credentials, prompt file, agent groups (model,
+count, custom endpoints, auth source), advanced settings
+(setup script, idle limit, git user), and post-processing.
+
+Output:
+  \$REPO_ROOT/swarm.json   Generated config file.
+
+Environment (auto-detected if set):
+  ANTHROPIC_API_KEY         API key.
+  CLAUDE_CODE_OAUTH_TOKEN   OAuth token for subscription auth.
+HELP
+    exit 0
+fi
+
 if command -v whiptail &>/dev/null; then
     USE_WHIPTAIL=true
 fi


### PR DESCRIPTION
## Summary

- Add `-h`/`--help` to all 7 non-test scripts: `launch.sh`, `setup.sh`, `dashboard.sh`, `costs.sh`, `harvest.sh`, `progress.sh`, `harness.sh`
- Each help message documents usage, available options/subcommands, keybindings (dashboard), and relevant environment variables
- `test.sh` already had `--help` so it was not touched

## Test plan

- [x] All 7 unit test suites pass (260 assertions, 0 failures)
- [x] Verified `--help` output for each script