### PR TITLE
Add run context trailers to commit messages

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -7,6 +7,9 @@ set -euo pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 SWARM_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT="$(basename "$REPO_ROOT")"
+SWARM_RUN_HASH="$(git -C "$REPO_ROOT" rev-parse --short=7 HEAD 2>/dev/null || echo "unknown")"
+SWARM_RUN_BRANCH="$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")"
+SWARM_RUN_CONTEXT="${PROJECT}@${SWARM_RUN_HASH} (${SWARM_RUN_BRANCH})"
 BARE_REPO="/tmp/${PROJECT}-upstream.git"
 IMAGE_NAME="${PROJECT}-agent"
 CONFIG_FILE="${SWARM_CONFIG:-}"
@@ -186,6 +189,9 @@ cmd_start() {
             -e "INJECT_GIT_RULES=${INJECT_GIT_RULES}" \
             -e "AGENT_ID=${AGENT_IDX}" \
             -e "SWARM_AUTH_MODE=${agent_auth}" \
+            -e "SWARM_RUN_CONTEXT=${SWARM_RUN_CONTEXT}" \
+            -e "SWARM_CFG_PROMPT=${AGENT_PROMPT}" \
+            -e "SWARM_CFG_SETUP=${AGENT_SETUP}" \
             "$IMAGE_NAME"
     done < "$AGENTS_CFG"
 
@@ -377,6 +383,9 @@ cmd_post_process() {
         -e "INJECT_GIT_RULES=${INJECT_GIT_RULES}" \
         -e "AGENT_ID=post" \
         -e "SWARM_AUTH_MODE=${pp_auth}" \
+        -e "SWARM_RUN_CONTEXT=${SWARM_RUN_CONTEXT}" \
+        -e "SWARM_CFG_PROMPT=${pp_prompt}" \
+        -e "SWARM_CFG_SETUP=${AGENT_SETUP:-}" \
         "$IMAGE_NAME"
 
     echo "Post-processing agent launched: ${NAME}"

--- a/lib/harness.sh
+++ b/lib/harness.sh
@@ -44,6 +44,9 @@ git config --global user.email "$GIT_USER_EMAIL"
 CLAUDE_VERSION=$(claude --version 2>/dev/null || echo "unknown")
 CLAUDE_VERSION="${CLAUDE_VERSION%% *}"
 export CLAUDE_VERSION
+export SWARM_RUN_CONTEXT="${SWARM_RUN_CONTEXT:-unknown}"
+export SWARM_CFG_PROMPT="${SWARM_CFG_PROMPT:-${AGENT_PROMPT}}"
+export SWARM_CFG_SETUP="${SWARM_CFG_SETUP:-${AGENT_SETUP}}"
 
 echo "[harness:${AGENT_ID}] Starting (model=${CLAUDE_MODEL}, prompt=${AGENT_PROMPT})..."
 
@@ -90,6 +93,10 @@ if [ ! -d "/workspace/.git" ]; then
 if ! grep -q '^Model:' "$1"; then
     printf '\nModel: %s\nTools: claude-swarm %s, Claude Code %s\n' \
         "$CLAUDE_MODEL" "$SWARM_VERSION" "$CLAUDE_VERSION" >> "$1"
+    printf '> Run: %s\n' "$SWARM_RUN_CONTEXT" >> "$1"
+    cfg="$SWARM_CFG_PROMPT"
+    [ -n "$SWARM_CFG_SETUP" ] && cfg="${cfg}, ${SWARM_CFG_SETUP}"
+    printf '> Cfg: %s\n' "$cfg" >> "$1"
 fi
 HOOK
     chmod +x .git/hooks/prepare-commit-msg


### PR DESCRIPTION
## Summary

- Capture source repo basename, commit hash, and branch at launch time
- Pass prompt file and setup script paths to each container as env vars
- Extend the `prepare-commit-msg` hook to append `> Run:` and `> Cfg:` context lines:
  ```
  Model: claude-opus-4-6
  Tools: claude-swarm 0.1.0, Claude Code 2.1.52
  > Run: netherfuzz@a3f8c21 (main)
  > Cfg: prompts/task.md, scripts/setup.sh
  ```
- `> Cfg:` omits the setup script when none is configured

## Test plan

- [x] `test_harness.sh` — hook tests updated: prompt + setup, prompt only (no setup), idempotency guard, different repos/branches
- [x] `test_launch.sh` — 53 existing tests still pass
- [x] Live test with agent swarm to verify trailers appear in commit history