### PR TITLE
Color full agent log line yellow

### DIFF
--- a/lib/activity-filter.sh
+++ b/lib/activity-filter.sh
@@ -6,10 +6,10 @@ set -euo pipefail
 #
 #   claude ... --output-format stream-json | tee "$LOG" | activity-filter.sh
 #
-# Each tool_use content block becomes one line with the
-# timestamp and agent ID in ANSI yellow (git-hash color):
-#   \033[33m12:34:56   agent[1]\033[0m Read src/main.ts
-#   \033[33m12:35:01   agent[1]\033[0m Shell: npm test
+# Each tool_use content block becomes one full-line ANSI
+# yellow output (matching harness green for visual contrast):
+#   \033[33m12:34:56   agent[1] Read src/main.ts\033[0m
+#   \033[33m12:35:01   agent[1] Shell: npm test\033[0m
 #
 # Uses a single jq invocation for efficiency (no per-line fork).
 
@@ -26,20 +26,23 @@ exec jq --unbuffered --raw-input --arg id "$AGENT_ID" -r '
     now | strftime("%H:%M:%S");
 
   def prefix:
-    "\u001b[33m\(ts)   agent[\($id)]\u001b[0m";
+    "\u001b[33m\(ts)   agent[\($id)]";
+
+  def reset:
+    "\u001b[0m";
 
   fromjson? // empty |
   select(.type == "assistant") |
   .message.content[]? |
   select(.type == "tool_use") |
-  if   .name == "Bash"  then "\(prefix) Shell: " + ((.input.command // "") | first_line | truncate(80))
-  elif .name == "Read"  then "\(prefix) Read "  + (.input.file_path // .input.path // "")
-  elif .name == "Write" then "\(prefix) Write " + (.input.file_path // .input.path // "")
-  elif .name == "Edit"  then "\(prefix) Edit "  + (.input.file_path // .input.path // "")
-  elif .name == "MultiEdit" then "\(prefix) MultiEdit " + (.input.file_path // .input.path // "")
-  elif .name == "Glob"  then "\(prefix) Glob "  + (.input.pattern // "")
-  elif .name == "Grep"  then "\(prefix) Grep "  + (.input.pattern // "")
-  elif .name == "Task"  then "\(prefix) Task: " + ((.input.description // .input.prompt // "") | first_line | truncate(60))
-  else "\(prefix) " + .name
+  if   .name == "Bash"  then "\(prefix) Shell: " + ((.input.command // "") | first_line | truncate(80)) + reset
+  elif .name == "Read"  then "\(prefix) Read "  + (.input.file_path // .input.path // "") + reset
+  elif .name == "Write" then "\(prefix) Write " + (.input.file_path // .input.path // "") + reset
+  elif .name == "Edit"  then "\(prefix) Edit "  + (.input.file_path // .input.path // "") + reset
+  elif .name == "MultiEdit" then "\(prefix) MultiEdit " + (.input.file_path // .input.path // "") + reset
+  elif .name == "Glob"  then "\(prefix) Glob "  + (.input.pattern // "") + reset
+  elif .name == "Grep"  then "\(prefix) Grep "  + (.input.pattern // "") + reset
+  elif .name == "Task"  then "\(prefix) Task: " + ((.input.description // .input.prompt // "") | first_line | truncate(60)) + reset
+  else "\(prefix) " + .name + reset
   end
 '

--- a/tests/test_activity_filter.sh
+++ b/tests/test_activity_filter.sh
@@ -208,7 +208,7 @@ assert_eq "agent padded 3 spaces" "   " "$PAD_SPACES"
 
 # ============================================================
 echo ""
-echo "=== 16. ANSI color in prefix ==="
+echo "=== 16. ANSI color — full line yellow ==="
 
 RAW=$(run_filter_raw 1 '{"type":"assistant","session_id":"s","message":{"id":"m","type":"message","role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"pwd"}}]}}')
 
@@ -221,7 +221,7 @@ else
     FAIL=$((FAIL + 1))
 fi
 
-# Reset (\033[0m) should appear after the agent ID.
+# Reset (\033[0m) should appear after the tool content.
 if printf '%s' "$RAW" | grep -qP '\x1b\[0m'; then
     echo "  PASS: has ANSI reset"
     PASS=$((PASS + 1))
@@ -230,9 +230,9 @@ else
     FAIL=$((FAIL + 1))
 fi
 
-# The tool name should be outside the colored region.
-AFTER_RESET=$(printf '%s' "$RAW" | sed 's/.*\x1b\[0m//')
-assert_contains "tool after reset" "Shell: pwd" "$AFTER_RESET"
+# The tool name should be inside the colored region (before reset).
+BEFORE_RESET=$(printf '%s' "$RAW" | sed 's/\x1b\[0m.*//')
+assert_contains "tool before reset" "Shell: pwd" "$BEFORE_RESET"
 
 # ============================================================
 echo ""


### PR DESCRIPTION
## Summary

- Agent activity lines now use full-line yellow instead of
  yellow prefix only, matching the harness's full-line green
  convention for consistent visual contrast.

## Test plan

- [x] Run `./tests/test.sh --unit` to verify activity filter tests pass
- [x] Press `[1-9]` in the dashboard during a run to confirm agent lines
      are fully yellow and harness lines are fully green