### PR TITLE
Reject `--agents` when config file defines agent groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Disable telemetry and nonessential traffic in agent containers
   (`CLAUDE_CODE_ENABLE_TELEMETRY=0`,
   `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1`).
+- Error out when `--agents` is used with a config file that defines
+  agent groups, instead of silently ignoring the flag.
 
 ## 0.9.2 — 2026-03-10
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -27,12 +27,12 @@ SWARM_PROMPT="path/to/prompt.md" \
 ./launch.sh post-process       # Run post-process agent.
 ```
 
-Start options (override env vars; config file sets agents):
+Start options (override env vars):
 
 ```
 --prompt FILE           Prompt file path.
 --model MODEL           Model name (default: claude-opus-4-6).
---agents N              Agent count (default: 3).
+--agents N              Agent count (default: 3; conflicts with config groups).
 --max-idle N            Idle sessions before exit (default: 3).
 --effort LEVEL          Reasoning effort: low, medium, high.
 --setup SCRIPT          Setup script path.

--- a/launch.sh
+++ b/launch.sh
@@ -20,10 +20,10 @@ Commands:
   wait                 Block until all agents exit, then harvest.
   post-process         Run the post-processing agent from the config.
 
-Start options (override env vars; ignored when config sets agents):
+Start options (override env vars):
   --prompt FILE        Prompt file path.
   --model MODEL        Model name (default: claude-opus-4-6).
-  --agents N           Agent count (default: 3).
+  --agents N           Agent count (default: 3; conflicts with config groups).
   --max-idle N         Idle sessions before exit (default: 3).
   --effort LEVEL       Reasoning effort: low, medium, high.
   --setup SCRIPT       Setup script path.
@@ -116,6 +116,7 @@ fi
 # Extracted as a function for testability.
 parse_start_args() {
     OPEN_DASHBOARD=false
+    AGENTS_CLI_OVERRIDE=false
     while [ $# -gt 0 ]; do
         case "$1" in
             --prompt)
@@ -126,6 +127,7 @@ parse_start_args() {
                 shift 2 ;;
             --agents)
                 NUM_AGENTS="${2:?--agents requires a value}"
+                AGENTS_CLI_OVERRIDE=true
                 shift 2 ;;
             --max-idle)
                 MAX_IDLE="${2:?--max-idle requires a value}"
@@ -167,6 +169,12 @@ cmd_start() {
 
     if [ ! -f "$REPO_ROOT/$SWARM_PROMPT" ]; then
         echo "ERROR: ${SWARM_PROMPT} not found." >&2
+        exit 1
+    fi
+
+    if $AGENTS_CLI_OVERRIDE && [ -n "$CONFIG_FILE" ]; then
+        echo "ERROR: --agents cannot override agent groups defined in ${CONFIG_FILE}." >&2
+        echo "       Edit the 'count' fields in ${CONFIG_FILE} instead." >&2
         exit 1
     fi
 

--- a/tests/test_launch.sh
+++ b/tests/test_launch.sh
@@ -458,6 +458,7 @@ reset_vars() {
     SWARM_SETUP=""
     INJECT_GIT_RULES="true"
     OPEN_DASHBOARD=false
+    AGENTS_CLI_OVERRIDE=false
 }
 
 reset_vars
@@ -538,7 +539,19 @@ assert_eq "combo dash"    "true"  "$OPEN_DASHBOARD"
 
 # ============================================================
 echo ""
-echo "=== 21. Auth label — credential source labels ==="
+echo "=== 21. --agents sets AGENTS_CLI_OVERRIDE flag ==="
+
+reset_vars
+parse_start_args --agents 5
+assert_eq "override flag set" "true" "$AGENTS_CLI_OVERRIDE"
+
+reset_vars
+parse_start_args --model m
+assert_eq "override flag unset" "false" "$AGENTS_CLI_OVERRIDE"
+
+# ============================================================
+echo ""
+echo "=== 22. Auth label — credential source labels ==="
 
 # auth_token set → "token"
 assert_eq "auth_token → token" \


### PR DESCRIPTION
## Summary

- `--agents N` now errors out when a config file with `.agents[]` groups is present, instead of silently ignoring the flag.
- Previously `--agents` set `NUM_AGENTS` (used by stop/status/wait) but the container launch loop read `.agents[].count` from the config directly, so the user would expect N agents but get the config's total.
- Updated help text in `launch.sh` and `USAGE.md` to reflect the new behavior.

## Context

Running `SWARM_CONFIG=swarm.json ./launch.sh start --agents 1` launched all 5 agents defined in the config. The error message now directs users to edit the `count` fields in their config instead.

## Test plan

- [x] `tests/test_launch.sh` passes (115/115, including 2 new assertions for the `AGENTS_CLI_OVERRIDE` flag)
- [x] `tests/test_harness.sh` passes (80/80)