### PR TITLE
Fix jq 1.8 split() on empty string in dashboard summary

### DIFF
--- a/dashboard.sh
+++ b/dashboard.sh
@@ -68,7 +68,7 @@ if [ -n "$CONFIG_FILE" ]; then
     fi
     NUM_AGENTS=$(jq '[.agents[].count] | add' "$CONFIG_FILE")
     MODEL_SUMMARY=$(jq -r \
-        '(.prompt // "") as $dp | ($dp | split("/") | .[-1] | rtrimstr(".md")) as $dp_stem |
+        '(.prompt // "") as $dp | ($dp | split("/") | .[-1] // "" | rtrimstr(".md")) as $dp_stem |
         [.agents[] |
           "\(.count)x \(.model | split("/") | .[-1])" +
           (if .context == "none" then " ctx:bare"

--- a/launch.sh
+++ b/launch.sh
@@ -267,7 +267,7 @@ cmd_start() {
         local price_input="" price_output="" price_cached=""
         local _price
         _price=$(jq -r --arg m "$agent_model" \
-            '.pricing[$m] // empty | "\(.input) \(.output) \(.cached // 0)"' \
+            '.pricing[$m] // empty | "\(.input + 0) \(.output + 0) \((.cached // 0) + 0)"' \
             "$CONFIG_FILE" 2>/dev/null || true)
         if [ -n "$_price" ]; then
             read -r price_input price_output price_cached <<< "$_price"
@@ -305,7 +305,7 @@ cmd_start() {
     # Write state file so a standalone dashboard can pick up config.
     local state_model_summary state_config_label
     state_model_summary=$(jq -r \
-        '(.prompt // "") as $dp | ($dp | split("/") | .[-1] | rtrimstr(".md")) as $dp_stem |
+        '(.prompt // "") as $dp | ($dp | split("/") | .[-1] // "" | rtrimstr(".md")) as $dp_stem |
         [.agents[] |
           "\(.count)x \(.model | split("/") | .[-1])" +
           (if .context == "none" then " ctx:bare"
@@ -462,7 +462,7 @@ cmd_post_process() {
     local price_input="" price_output="" price_cached=""
     local _price
     _price=$(jq -r --arg m "$pp_model" \
-        '.pricing[$m] // empty | "\(.input) \(.output) \(.cached // 0)"' \
+        '.pricing[$m] // empty | "\(.input + 0) \(.output + 0) \((.cached // 0) + 0)"' \
         "$CONFIG_FILE" 2>/dev/null || true)
     if [ -n "$_price" ]; then
         read -r price_input price_output price_cached <<< "$_price"

--- a/tests/test_config.sh
+++ b/tests/test_config.sh
@@ -480,7 +480,7 @@ assert_eq "with top prompt, present" "true" "$(all_groups_have_prompt "$TMPDIR/a
 
 # Model summary jq handles missing top-level prompt gracefully.
 MODEL_SUM=$(jq -r \
-    '(.prompt // "") as $dp | ($dp | split("/") | .[-1] | rtrimstr(".md")) as $dp_stem |
+    '(.prompt // "") as $dp | ($dp | split("/") | .[-1] // "" | rtrimstr(".md")) as $dp_stem |
     [.agents[] |
       "\(.count)x \(.model | split("/") | .[-1])" +
       (if .context == "none" then " ctx:bare"

--- a/tests/test_launch.sh
+++ b/tests/test_launch.sh
@@ -687,7 +687,7 @@ echo "=== 13. Pricing extraction from config ==="
 extract_pricing() {
     local config="$1" model="$2"
     jq -r --arg m "$model" \
-        '.pricing[$m] // empty | "\(.input) \(.output) \(.cached // 0)"' \
+        '.pricing[$m] // empty | "\(.input + 0) \(.output + 0) \((.cached // 0) + 0)"' \
         "$config" 2>/dev/null || true
 }
 


### PR DESCRIPTION
## Summary      
  - `split("/") | .[-1]` returns `null` on empty strings in jq 1.8+ (previously returned `""`), causing `rtrimstr()` to error with `endswith() requires string inputs`
  - Add `// ""` fallback to handle the `null` case; backward compatible with older jq                                                                                 
                                                                                                                                                                                                                                                         
  ## Test plan                                                                                                                                                                                                                                           
  - [x] `jq --version` returns 1.8+ and `./launch.sh start` succeeds with an empty top-level `prompt` field
  - [x] Backward compatibility