### PR TITLE
Add Changes section to PR template and strengthen tagging policy

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -54,11 +54,14 @@
 
 ## Releases
 
-- Tag every release as an annotated tag on the merge commit
-  that lands the version bump on master.
-- Format: `git tag -a v$VERSION $COMMIT -m "v$VERSION — summary"`.
-- Summary: terse, covers the headline feature(s).
-- Remind the user to push tags (`git push origin --tags`).
+- After every merge to master that changes VERSION,
+  immediately create an annotated tag on the merge commit:
+  `git tag -a v$VERSION $MERGE_COMMIT -m "v$VERSION — summary"`.
+- Verify: `git tag -l "v$(cat VERSION)"`.  If the tag is
+  missing, create it before doing anything else.
+- Always prompt the user to push: `git push origin --tags`.
+- Never skip tagging.  A version bump without a tag is
+  incomplete.
 
 ## Quality bars
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -27,6 +27,9 @@
        ## Summary
        - Bullet per logical change. What and why.
 
+       ## Changes
+       - Per-file summary: what changed and why.
+
        ## Test plan
        - [ ] Concrete verification steps.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,8 @@
 ## Summary
 <!-- One or more bullet points describing the change. -->
 
+## Changes
+<!-- Per-file summary: what changed and why. -->
+
 ## Test plan
 <!-- How was this tested? Checklist of verification steps. -->


### PR DESCRIPTION
## Summary

- Add the missing `## Changes` section to the PR template and
  CLAUDE.md so all PRs follow the three-section structure:
  Summary, Changes, Test plan.
- Rewrite the Releases section in CLAUDE.md to make tagging a
  mandatory post-merge action with a verification step, rather
  than a passive reminder.

## Changes

- `.github/PULL_REQUEST_TEMPLATE.md`: Add `## Changes` section
  between Summary and Test plan
- `.claude/CLAUDE.md`: Add `## Changes` to the PR body format;
  rewrite `## Releases` to require immediate tagging after every
  merge that changes VERSION, with a verify-before-proceed rule

## Test plan

- [x] PR template renders three sections on GitHub
- [x] CLAUDE.md PR format matches template structure
- [x] Tagging policy includes verification command