### PR TITLE
Fix docs/code mismatches across help text, USAGE, README, and comments

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -28,6 +28,6 @@ body:
     attributes:
       label: Version
       description: Output of `cat VERSION` or git tag.
-      placeholder: "0.18.1"
+      placeholder: "cat VERSION"
     validations:
       required: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,8 @@ jobs:
       - name: ShellCheck
         run: |
           shellcheck -s bash --severity=warning \
-            launch.sh dashboard.sh harvest.sh costs.sh \
+            launch.sh setup.sh dashboard.sh harvest.sh \
+            costs.sh progress.sh \
             lib/*.sh lib/drivers/*.sh \
             tests/test_*.sh tests/test.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,7 +184,7 @@
   `SWARM_MODEL` is unset, removing the hardcoded Claude default.
 - **Conditional Dockerfile.** `SWARM_AGENTS` build arg controls which
   CLIs are installed: `claude-code` (default), `gemini-cli`, or both.
-  Node.js 20 is only installed when Gemini CLI is needed. `launch.sh`
+  Node.js 22 is only installed when Gemini CLI is needed. `launch.sh`
   derives the arg from config and passes it to `docker build`.
 - **Dashboard driver label.** `format_model()` shows a `[gem]` or
   `[fake]` suffix when the agent's driver is not the default

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Based on the agent-team pattern from
 ## Prerequisites
 
 - [Docker](https://docs.docker.com/get-docker/)
-- bash (4.0+), git, jq, bc
+- bash (5.0+), git, jq, bc
 - tput (ncurses) — used by the dashboard
 - An Anthropic API key, OAuth token, or compatible endpoint
 
@@ -131,5 +131,4 @@ Each driver implements a fixed role interface:
 
 Built-in drivers: `claude-code` (default), `gemini-cli`,
 `fake` (test double).  See [USAGE.md](USAGE.md#writing-a-new-driver)
-for the full 13-function interface and guide to writing a new
-driver.
+for the full interface and guide to writing a new driver.

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Groups without `api_key` use `ANTHROPIC_API_KEY` or
 
 **Per-group fields:** `model`, `count`, `effort`, `context`,
 `prompt`, `auth`, `api_key`, `auth_token`, `base_url`, `tag`,
-`driver`, `inject_git_rules`. See [USAGE.md](USAGE.md) for
+`driver`. See [USAGE.md](USAGE.md) for
 field reference, environment variables, auth modes, context
 modes, per-group prompts, and agent drivers.
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -58,9 +58,10 @@ Per-group fields in `swarm.json` `agents` array:
 | `tag` | string or `$VAR` | Label for grouping runs (default: top-level). |
 | `driver` | driver name | Agent driver override (default: top-level or `claude-code`). |
 
-Top-level fields: `prompt`, `setup`, `max_idle`, `max_retry_wait`,
-`driver`, `inject_git_rules`, `claude_code_version`, `title`, `tag`,
-`pricing`, `docker_args`, `post_process`.
+Top-level fields: `prompt`, `setup`, `max_idle` (default: `3`),
+`max_retry_wait`, `driver`, `inject_git_rules`,
+`git_user` (`name`, `email`), `claude_code_version`, `title`,
+`tag`, `pricing`, `docker_args`, `post_process`.
 
 ### Retry on rate limits
 
@@ -150,6 +151,7 @@ events only for models that support them.
 ./tests/test.sh --all                # Full matrix.
 ./tests/test.sh --config swarm.json  # Custom config.
 ./tests/test.sh --no-inject          # Explicit git prompt.
+./tests/test.sh --oauth              # OAuth-only smoke test.
 ```
 
 Flags combine: `./tests/test.sh --config f.json --no-inject`.
@@ -193,6 +195,11 @@ or automatically via `./launch.sh wait`.
 
 The post-process agent clones the same bare repo, sees all
 commits on `agent-work`, runs its prompt, and pushes.
+
+`post_process` also accepts `base_url`, `api_key`,
+`auth_token`, `auth`, `tag`, and `driver` -- same fields as
+per-group agents -- to route post-processing through a
+different provider or credential.
 
 ## Context modes
 
@@ -390,8 +397,11 @@ agent_is_retriable()    # Detect retriable errors (rate limits, overload)
 agent_activity_jq()     # Return jq filter for activity streaming
 agent_docker_env()      # Print -e flags for agent-specific env vars
 agent_docker_auth()     # Resolve credentials, emit Docker -e flags
-agent_install_cmd()     # Dockerfile fragment to install the CLI
+agent_install_cmd()     # Print install commands (documentation only)
 ```
+
+The Dockerfile hardcodes install steps for built-in drivers.
+New drivers require corresponding Dockerfile changes.
 
 See `lib/drivers/claude-code.sh` for the reference implementation
 and `lib/drivers/fake.sh` for a minimal test double.
@@ -443,15 +453,13 @@ After a swarm run, the following artifacts remain on disk:
 | Submodule mirrors | `/tmp/<project>-mirror-*.git` |
 | Agent containers | `<project>-agent-N` |
 | State file | `/tmp/<project>-swarm.env` |
-| Agent config | `/tmp/<project>-agents.cfg` |
-
 Remove everything for a fresh start:
 
 ```bash
 PROJECT=$(basename $(pwd))
 docker rm -f $(docker ps -aq --filter "name=${PROJECT}-agent-") 2>/dev/null
 rm -rf /tmp/${PROJECT}-upstream.git /tmp/${PROJECT}-mirror-*.git
-rm -f  /tmp/${PROJECT}-swarm.env /tmp/${PROJECT}-agents.cfg
+rm -f  /tmp/${PROJECT}-swarm.env
 ```
 
 ## Verify image

--- a/USAGE.md
+++ b/USAGE.md
@@ -102,7 +102,7 @@ other flags that the harness does not manage natively.
 ```
 
 Per-agent model, auth source, status, cost, tokens, cache,
-turns, throughput, and duration.  Updates every 2-3s.  The
+turns, throughput, and duration.  Updates every 3s.  The
 header shows a compact model summary on a single line.
 
 | Key | Action |
@@ -110,7 +110,7 @@ header shows a compact model summary on a single line.
 | `q` | Quit. |
 | `1`-`9` | Logs for agent N. |
 | `h` | Harvest results. |
-| `s` | Stop all agents. |
+| `s` | Stop numbered agents (not post-process). |
 | `p` | Post-process. |
 
 ## Activity streaming

--- a/USAGE.md
+++ b/USAGE.md
@@ -55,7 +55,6 @@ Per-group fields in `swarm.json` `agents` array:
 | `api_key` | key or `$VAR` | Per-group API key for third-party endpoints. |
 | `auth_token` | key or `$VAR` | Per-group Bearer token (OpenRouter-style). |
 | `base_url` | URL | Per-group API endpoint. |
-| `inject_git_rules` | `true`, `false` | Append git coordination rules to system prompt. |
 | `tag` | string or `$VAR` | Label for grouping runs (default: top-level). |
 | `driver` | driver name | Agent driver override (default: top-level or `claude-code`). |
 

--- a/costs.sh
+++ b/costs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-# Print cost and usage summary for all swarm agents.
+# Print cost and usage summary for swarm containers.
 # Usage: ./costs.sh [--json]
 
 SWARM_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -10,7 +10,8 @@ if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
     cat <<HELP
 Usage: $0 [--json]
 
-Print cost and usage summary for all swarm agents.
+Print cost and usage summary for swarm containers
+(numbered agents and the post-process container).
 
 Options:
   --json   Output as JSON instead of a formatted table.

--- a/dashboard.sh
+++ b/dashboard.sh
@@ -11,14 +11,14 @@ if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
 Usage: $0
 
 Always-on TUI dashboard for swarm agents.
-Refreshes every 2 seconds. Shows per-agent model, auth source,
-status, cost, token usage, cache hits, turns, and duration.
+Refreshes every 3 seconds. Shows per-agent model, auth source,
+status, cost, token usage, cache tokens, turns, and duration.
 
 Keybindings:
   q           Quit the dashboard.
   1-9         Tail logs for agent N.
   h           Harvest agent results into current branch.
-  s           Stop all agents.
+  s           Stop numbered agents (not post-process).
   p           Run post-processing agent.
 
 Environment:
@@ -319,7 +319,7 @@ emit_header() {
 }
 
 draw() {
-    # Re-read state file so display updates between test cases.
+    # Re-read state file so display updates on every refresh.
     if [ -f "$STATE_FILE" ]; then
         # shellcheck disable=SC1090
         source "$STATE_FILE"

--- a/launch.sh
+++ b/launch.sh
@@ -8,16 +8,18 @@ SWARM_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
     cat <<HELP
-Usage: $0 COMMAND [OPTIONS]
+Usage: $0 [COMMAND] [OPTIONS]
 
 Orchestrate coding agents in Docker containers.
+Default command is 'start' when none is specified.
 
 Commands:
   start [OPTIONS]      Build image, create bare repo, launch agents.
   stop                 Stop all running agent containers.
   logs N               Tail logs for agent N (default: 1).
   status               Show running/stopped state for each agent.
-  wait                 Block until all agents exit, then harvest.
+  wait                 Block until all agents exit, then harvest
+                       (runs post-process first if configured).
   post-process         Run the post-processing agent from the config.
 
 Start options:
@@ -28,6 +30,7 @@ Environment:
   CLAUDE_CODE_OAUTH_TOKEN   OAuth token for subscription auth.
   SWARM_CONFIG              Path to swarmfile (or place swarm.json in repo root).
   SWARM_TITLE               Dashboard title override.
+  SWARM_SKIP_DEP_CHECK      Set to 1 to silence version warnings.
 HELP
     exit 0
 fi

--- a/lib/harness.sh
+++ b/lib/harness.sh
@@ -15,14 +15,14 @@ sessions until the agent is idle for MAX_IDLE cycles.
 
 Required environment:
   SWARM_PROMPT   Path to prompt file (relative to repo root).
-  SWARM_MODEL    Model to use for agent sessions.
 
 Optional environment:
+  SWARM_MODEL    Model (default: driver's default model).
   AGENT_ID       Agent identifier (default: unnamed).
   SWARM_DRIVER   Agent driver (default: claude-code).
   SWARM_SETUP    Setup script to run before first session.
   MAX_IDLE       Idle sessions before exit (default: 3).
-  MAX_RETRY_WAIT Max seconds to retry on rate limits (default: 0 = no retry).
+  MAX_RETRY_WAIT Max seconds to retry on fatal errors (default: 0 = no retry).
   INJECT_GIT_RULES  Inject git coordination rules (default: true).
   SWARM_CONTEXT  Context mode: full (default), slim, or none.
 HELP
@@ -324,7 +324,7 @@ while true; do
         if [ -n "$_retriable" ] && [ "$MAX_RETRY_WAIT" -gt 0 ]; then
             _backoff=30; _total_waited=0
             while [ "$_total_waited" -lt "$MAX_RETRY_WAIT" ]; do
-                hlog_err "rate limited: ${FATAL_MSG}"
+                hlog_err "retriable error: ${FATAL_MSG}"
                 hlog "retrying in ${_backoff}s (waited ${_total_waited}/${MAX_RETRY_WAIT}s)"
                 printf '%s/%s\n' "$_total_waited" "$MAX_RETRY_WAIT" > "$RETRY_FILE"
                 sleep "$_backoff"

--- a/progress.sh
+++ b/progress.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 set -euo pipefail
 
-# Show what agents have pushed to the bare repo.
+# Show recent commits on agent-work and running containers.
 
 if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
     cat <<HELP
 Usage: $0
 
-Show what agents have pushed to the bare repo.
-Clones the bare repo to a temp directory, displays recent
-commits on agent-work, and lists running agent containers.
+Show recent commits on agent-work and running containers.
+Clones the bare repo to a temp directory, displays the last
+15 commits on agent-work, and lists running containers.
 HELP
     exit 0
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -223,7 +223,7 @@ GIT_EMAIL="agent@swarm.local"
 TAG=""
 DRIVER="claude-code"
 
-if yesno "Configure advanced settings (setup script, idle limit, git user)?"; then
+if yesno "Configure advanced settings (setup script, idle limit, git user, tag, driver)?"; then
     SETUP_PATH=$(input "Setup script path (blank to skip)" "")
     MAX_IDLE=$(input "Max idle sessions before exit" "3")
     GIT_NAME=$(input "Git user name for agent commits" "swarm-agent")

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -200,7 +200,7 @@ assert_eq "auth config valid" "true" \
 echo ""
 echo "=== 10. Auto auth from single credential ==="
 
-# Mirrors the agent-object auth logic from setup.sh lines 149-170:
+# Mirrors the agent-object auth logic from setup.sh:
 #   custom endpoint  → base_url/api_key (no auth field)
 #   both creds       → user picks (auto/apikey/oauth)
 #   oauth only       → auth: oauth


### PR DESCRIPTION
## Summary
- Audit all documentation, help text, and comments against
  actual code behavior; fix every mismatch found.
- 12 files, 10 commits, each addressing a logical group of
  related inaccuracies.
- No behavioral changes -- only help strings, comments, docs,
  and CI config.

## Changes
- **USAGE.md / README.md**: Remove `inject_git_rules` from
  per-group table (only top-level in code). Add `git_user` and
  `max_idle` default to top-level list. Document `post_process`
  sub-fields. Add `--oauth` test flag. Clarify
  `agent_install_cmd` is documentation-only. Remove stale
  `agents.cfg` from cleanup table. Fix dashboard refresh and
  stop scope descriptions.
- **dashboard.sh**: Help said 2s refresh (code uses 3s), "cache
  hits" (shows tokens), "stop all" (skips post-process),
  `draw()` comment said "test cases" (runs every refresh).
- **lib/harness.sh**: `SWARM_MODEL` documented as required but
  defaults via `agent_default_model()`. Retry log said "rate
  limited" for any retriable fatal. `MAX_RETRY_WAIT` help
  narrower than actual retry scope.
- **launch.sh**: Help omitted default `start` command, `wait`
  post-process path, and `SWARM_SKIP_DEP_CHECK`.
- **costs.sh / progress.sh**: Help text overclaimed scope.
- **README.md**: bash 4.0+ but tested minimum is 5.0. "13-function
  interface" claim drifts from inline table.
- **CHANGELOG.md**: 0.11.0 said Node 20, Dockerfile uses 22.
- **setup.sh**: `yesno` prompt omitted tag and driver.
- **CI**: Add `setup.sh` and `progress.sh` to shellcheck.
- **Bug template**: Replace version placeholder with `cat VERSION`.
- **tests/test_setup.sh**: Remove stale line-number reference.

## Test plan
- [x] `./tests/test.sh --unit` -- 915 tests pass.
- [x] Verified `shellcheck` passes on newly added files.
- [x] Confirmed "rate limited" log string is not parsed
  anywhere (only cosmetic).