### PR TITLE
Add single-concern checklist to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,5 +4,9 @@
 ## Changes
 <!-- Per-file summary: what changed and why. -->
 
+## Self-review checklist
+<!-- Check all that apply before requesting review. -->
+- [ ] This PR addresses a **single concern** ([why?](https://blog.ploeh.dk/2015/01/15/10-tips-for-better-pull-requests/#2-do-only-one-thing)). If it covers multiple independent changes, I've split them into separate PRs.
+
 ## Test plan
 <!-- How was this tested? Checklist of verification steps. -->


### PR DESCRIPTION
## Summary
- Add a self-review checklist to the PR template with a checkbox asking authors to confirm their PR addresses a single concern
- Links to the [relevant section](https://blog.ploeh.dk/2015/01/15/10-tips-for-better-pull-requests/#2-do-only-one-thing) of ploeh's "10 tips for better Pull Requests" for rationale

## Test plan
- [x] Open a new PR and verify the checklist renders correctly with the checkbox and link