### PR TITLE
Add max-opus test config for maximum Opus 4.6 usage

### DIFF
--- a/tests/configs/max-opus.json
+++ b/tests/configs/max-opus.json
@@ -1,0 +1,19 @@
+{
+  "prompt": "unused",
+  "docker_args": [
+    "-e", "CLAUDE_CODE_SUBAGENT_MODEL=claude-opus-4-6",
+    "-e", "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING=1",
+    "-e", "MAX_THINKING_TOKENS=127999",
+    "-e", "CLAUDE_CODE_DISABLE_AUTO_MEMORY=1",
+    "-e", "TASK_MAX_OUTPUT_LENGTH=160000"
+  ],
+  "agents": [
+    {
+      "count": 1,
+      "model": "claude-opus-4-6",
+      "effort": "max",
+      "context": "slim",
+      "auth": "oauth"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds `tests/configs/max-opus.json` -- a reference config that maximizes Opus 4.6 reasoning depth.

### Motivation

anthropics/claude-code#42796 documented that adaptive thinking can be silently rationed under platform load, with estimated thinking depth varying up to 8.8x by time of day. This config opts out of adaptive thinking entirely in favor of a guaranteed fixed budget.

### docker_args breakdown

| Env var | Why |
|---------|-----|
| `CLAUDE_CODE_SUBAGENT_MODEL=claude-opus-4-6` | Subagents default to Sonnet/Haiku. Security reasoning in subagents (code exploration, plan mode) needs Opus too. |
| `CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING=1` | Prevents load-based thinking rationing documented in anthropics/claude-code#42796. Falls back to fixed budget. |
| `MAX_THINKING_TOKENS=127999` | Opus 4.6 ceiling (128k max output - 1). Guarantees full thinking budget every turn regardless of platform conditions. |
| `CLAUDE_CODE_DISABLE_AUTO_MEMORY=1` | Scanning sessions are one-shot runs. Auto memory adds context overhead for no benefit. |
| `TASK_MAX_OUTPUT_LENGTH=160000` | Max allowed (default: 32000). Subagents returning vulnerability findings shouldn't be truncated. |

## Test plan

- [x] `./tests/test.sh --config tests/configs/max-opus.json --oauth` passes