### PR TITLE
Relax commit lint

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -17,7 +17,58 @@
 - `./tests/test.sh --unit` for unit tests only.
 - `./tests/test.sh --help` for flags.
 
+## Commit messages
+
+Prefer short, plain commit subjects.
+
+Guidelines:
+
+- Start with an uppercase imperative verb.
+- Keep the subject concise.
+- Do not end the subject with a period.
+- Avoid semantic prefixes unless they are already used
+  nearby.
+- Squash `fixup!`, `squash!`, and `wip` commits before
+  opening or merging a PR.
+
+Good examples:
+
+- Add Codex driver
+- Fix swarm timeout handling
+- Split driver configuration
+
+Avoid:
+
+- add codex driver
+- Fix swarm timeout handling.
+- fixup! Add Codex driver
+- wip driver changes
+
+This isn't pedantry: commit subjects flow into CHANGELOG
+entries and the annotated message of each release tag, so a
+clean subject saves everyone a moment of "wait, what does
+this say?" months later.  Don't agonize over any single
+subject though -- aim for something a teammate can skim and
+you're there.
+
 ## Pull requests
+
+Before requesting review:
+
+- Rebase onto latest `master` -- please don't merge `master`
+  into your branch.  We keep `master` linear with one merge
+  commit per PR so `git log --oneline --graph` stays
+  readable for everyone (the shape is "straight line, jump
+  out into a feature, jump back, straight line").  Feature
+  branches catch up by rebasing so their own history also
+  stays a straight line for reviewers.
+- Keep PRs focused and reviewable -- it's much easier to
+  give a thorough review on a tight PR than a sprawling one.
+- Prefer draft PRs for large or exploratory changes so
+  collaborators can chime in early without it reading as a
+  finished proposal.
+
+Drafting the PR:
 
 1. Run `git diff --stat origin/master..HEAD` and
    `git log --oneline origin/master..HEAD`.
@@ -75,10 +126,11 @@
 - Curly braces over one-line conditionals.
 - Direct wording, no filler verbs.
 - Comments end with a dot.
-- Commit subjects: imperative, specific.  Max 72 chars,
-  start with uppercase, no trailing period, no
-  `fixup!`/`squash!` prefixes (enforced by CI).
 - Commit bodies: motivation, not just what changed.
 - Sentences in commit bodies end with a dot.
+- CI rejects `fixup!`, `squash!`, and `wip` subjects, and
+  fails the PR if the branch is behind `master`.  Subject
+  style otherwise (capitalization, length, trailing period)
+  is guidance, not enforcement -- see "Commit messages".
 
 <!-- CANARY: 114c1e52b479dc2795c42b655f73a15fd26d747d -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,23 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+
+      - name: Fetch master
+        run: |
+          git fetch origin master:refs/remotes/origin/master
+
+      - name: Ensure branch is up to date with master
+        run: |
+          head="${{ github.event.pull_request.head.sha }}"
+          if ! git merge-base --is-ancestor origin/master "$head"; then
+            echo "::error::PR branch is behind master. Please rebase onto"
+            echo "::error::master (we keep master linear -- don't merge"
+            echo "::error::master into your branch)."
+            exit 1
+          fi
+
       - name: Validate commit messages
         run: |
           base="${{ github.event.pull_request.base.sha }}"
@@ -56,24 +72,9 @@ jobs:
             if git log -1 --format='%P' "$sha" | grep -q ' '; then
               continue
             fi
-            # Must start with uppercase.
-            if ! echo "$subject" | grep -qE '^[A-Z]'; then
-              echo "::error::Commit $sha: subject must start with uppercase: $subject"
-              ok=false
-            fi
-            # No trailing period.
-            if echo "$subject" | grep -qE '\.$'; then
-              echo "::error::Commit $sha: subject must not end with a period: $subject"
-              ok=false
-            fi
-            # Max 72 characters.
-            if [ "${#subject}" -gt 72 ]; then
-              echo "::error::Commit $sha: subject exceeds 72 characters (${#subject}): $subject"
-              ok=false
-            fi
-            # No fixup/squash leftovers.
-            if echo "$subject" | grep -qE '^(fixup|squash)!'; then
-              echo "::error::Commit $sha: fixup/squash commits must be cleaned up: $subject"
+            # Reject cleanup commits that should not land in history.
+            if echo "$subject" | grep -qEi '^(fixup|squash|wip)!?'; then
+              echo "::error::Commit $sha must be cleaned up: $subject"
               ok=false
             fi
           done < <(git rev-list "$base".."$head")

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -290,6 +290,18 @@ cmd_unit() {
             [ -n "$n" ] && total_tests=$((total_tests + n))
         else
             printf "  FAIL  %-24s\n" "$name"
+            # Surface explicit FAIL: lines (with the expected/actual
+            # context printed by assert_eq/assert_contains) before
+            # the tail snippet -- when many assertions run after the
+            # failing one, tail -20 buries the FAIL: marker and CI
+            # logs lose the only diagnostic.
+            local fail_lines
+            fail_lines=$(printf '%s\n' "$output" \
+                | grep -A 2 '^  FAIL:' || true)
+            if [ -n "$fail_lines" ]; then
+                printf '%s\n' "$fail_lines" | sed 's/^/        /'
+                echo "        ---"
+            fi
             printf '%s\n' "$output" | tail -20 | sed 's/^/        /'
             fail=$((fail + 1))
         fi


### PR DESCRIPTION
A lot of the strict ruleset is a holdover from when this repo lived at github.com/moodmosaic/claude-swarm as a personal project --- the subject-style checks were largely my own taste.

Now that it's under protocol-security (with most likely more contributors), the right move is to soften what's stylistic while keeping the rules that actually carry their weight on long-term maintenance:
- linear history
- no `fixup!` / `squash!` leftovers in `git log`
- and branches up to date with `master` before merge.

---

Subject style (capitalization, length, trailing period) is guidance now -- not enforcement.

(We're not chasing pedantry, but commit subjects do feed `CHANGELOG` entries and the annotated message of each release tag, so a clean subject pays off when reading history months later.)

CI still rejects the things that actually hurt history: `fixup!` / `squash!` / `wip` subjects, and PRs whose branch is behind `master` (we keep `master` linear, so the remediation asks for rebase rather than merge).
