### PR TITLE
Add support for custom codex-cli version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,9 @@ RUN if echo ",$SWARM_AGENTS," | grep -q ",gemini-cli,"; then \
     fi
 
 # --- Codex CLI ---
+ARG CODEX_CLI_VERSION=
 RUN if echo ",$SWARM_AGENTS," | grep -q ",codex-cli,"; then \
-        npm install -g @openai/codex \
+        npm install -g "@openai/codex${CODEX_CLI_VERSION:+@$CODEX_CLI_VERSION}" \
         && mkdir -p /home/agent/.codex \
         && chown agent:agent /home/agent/.codex; \
     fi

--- a/launch.sh
+++ b/launch.sh
@@ -260,7 +260,7 @@ cmd_start() {
     local _cc_version
     _cc_version=$(jq -r '.claude_code_version // empty' "$CONFIG_FILE" 2>/dev/null || true)
     local _codex_cli_version
-    _codex_cli_version=$(jq -r '._codex_cli_version // empty' "$CONFIG_FILE" 2>/dev/null || true)
+    _codex_cli_version=$(jq -r '.codex_cli_version // empty' "$CONFIG_FILE" 2>/dev/null || true)
 
     echo "--- Building agent image (agents: ${_swarm_agents}) ---"
     docker build -t "$IMAGE_NAME" \

--- a/launch.sh
+++ b/launch.sh
@@ -259,11 +259,14 @@ cmd_start() {
 
     local _cc_version
     _cc_version=$(jq -r '.claude_code_version // empty' "$CONFIG_FILE" 2>/dev/null || true)
+    local _codex_cli_version
+    _codex_cli_version=$(jq -r '._codex_cli_version // empty' "$CONFIG_FILE" 2>/dev/null || true)
 
     echo "--- Building agent image (agents: ${_swarm_agents}) ---"
     docker build -t "$IMAGE_NAME" \
         --build-arg "SWARM_AGENTS=${_swarm_agents}" \
         ${_cc_version:+--build-arg "CLAUDE_CODE_VERSION=${_cc_version}"} \
+        ${_codex_cli_version:+--build-arg "CODEX_CLI_VERSION=${_codex_cli_version}"} \
         -f "$SWARM_DIR/Dockerfile" "$SWARM_DIR"
 
     # Build mirror volume args from discovered submodules.

--- a/lib/drivers/codex-cli.sh
+++ b/lib/drivers/codex-cli.sh
@@ -304,8 +304,9 @@ agent_docker_auth() {
 }
 
 # Dockerfile fragment to install this agent's CLI.
+# CODEX_CLI_VERSION is a Docker build-arg; empty = latest.
 agent_install_cmd() {
     cat <<'INSTALL'
-RUN npm install -g @openai/codex
+RUN npm install -g "@openai/codex${CODEX_CLI_VERSION:+@$CODEX_CLI_VERSION}"
 INSTALL
 }

--- a/tests/test_drivers.sh
+++ b/tests/test_drivers.sh
@@ -820,6 +820,7 @@ assert_contains "codex jq has changes path" "changes" "$CDX_JQ"
 CDX_INSTALL=$(agent_install_cmd)
 assert_contains "codex install has npm" "npm" "$CDX_INSTALL"
 assert_contains "codex install has @openai/codex" "@openai/codex" "$CDX_INSTALL"
+assert_contains "codex install supports version" "CODEX_CLI_VERSION" "$CDX_INSTALL"
 
 # ============================================================
 echo ""

--- a/tests/test_launch.sh
+++ b/tests/test_launch.sh
@@ -5,6 +5,12 @@ set -euo pipefail
 # Unit tests for launch.sh parsing logic.
 # No Docker or API key required.
 
+# Isolate from host gitconfig (signing keys, hooks, templates).
+# Several tests build scratch repos and run `git commit` /
+# `commit-tree`;
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_SYSTEM=/dev/null
+
 PASS=0
 FAIL=0
 TMPDIR=$(mktemp -d)

--- a/tests/test_session_end_push.sh
+++ b/tests/test_session_end_push.sh
@@ -11,6 +11,11 @@ set -euo pipefail
 #   the hook-suppression mechanism end-to-end, and pin the
 #   park-push retry loop both structurally and behaviorally.
 
+# Isolate from host gitconfig (signing keys, hooks, templates).
+# This test exercises rebase/push mechanics, not signing.
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_SYSTEM=/dev/null
+
 PASS=0
 FAIL=0
 TMPDIR=$(mktemp -d)


### PR DESCRIPTION
## Summary
This PR makes the Codex CLI version configurable per swarm via a `codex_cli_version` field in the swarm config file, mirroring the existing `claude_code_version` build-arg path. It also isolates `test_session_end_push.sh` and `test_launch.sh` from the host gitconfig so it no longer trips over a developer's `commit.gpgsign` + SSH-SK setup when running its scratch-repo commits, as it was blocking me from running the unit tests.

## Changes
- `Dockerfile`: declare `ARG CODEX_CLI_VERSION=` next to the Codex install step and switch the install line to
  `npm install -g "@openai/codex${CODEX_CLI_VERSION:+@$CODEX_CLI_VERSION}"`, so an empty arg keeps the previous "latest" behavior.
- `launch.sh`: read `codex_cli_version` from the swarmfile via `jq` and forward it as a `--build-arg` only when set,
  matching the surrounding `_cc_version` pattern.
- `lib/drivers/codex-cli.sh`: update `agent_install_cmd`'s Dockerfile fragment to the same templated install line and
  add a comment documenting `CODEX_CLI_VERSION`.  No inline `ARG` in the heredoc, to stay consistent with
  `claude-code.sh`.
- `tests/test_drivers.sh`: assert the codex install snippet references `CODEX_CLI_VERSION`, so the version hook can't silently regress.
- `tests/test_session_end_push.sh`: export `GIT_CONFIG_GLOBAL=/dev/null` and `GIT_CONFIG_SYSTEM=/dev/null` at the top of the file.  The test exercises rebase/push mechanics, not signing, so any host-side `commit.gpgsign` config (e.g. SSH-SK hardware keys) would otherwise prompt for a hardware-key touch on every internal `git commit` and fail the regression arm.

## Self-review checklist
- [ ] This PR addresses a **single concern** ([why?](https://blog.ploeh.dk/2015/01/15/10-tips-for-better-pull-requests/#2-do-only-one-thing)). If it covers multiple independent changes, I've split them into separate PRs.

## Test plan
- [ ] `./tests/test.sh --unit` -- expect 11 files, 1182 tests, 0 failed (test_session_end_push now passes on hosts with
  SSH-SK signing enabled).
- [ ] Build with no override: `docker build --build-arg SWARM_AGENTS=codex-cli .` and confirm `codex --version` reports the latest published release.
- [ ] Build with a pinned version: add `"codex_cli_version": "0.20.0"` to a swarmfile, run `./launch.sh start`, and confirm the resulting image's `codex --version` matches the pin.
