### PR TITLE
Use ASCII -- in tag message rule

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -112,7 +112,7 @@ Drafting the PR:
   `CHANGELOG.md`.  Code lives in its own preceding commit.
 - After every merge to master that changes VERSION,
   immediately create an annotated tag on the merge commit:
-  `git tag -a v$VERSION $MERGE_COMMIT -m "v$VERSION — summary"`.
+  `git tag -a v$VERSION $MERGE_COMMIT -m "v$VERSION -- summary"`.
 - Verify: `git tag -l "v$(cat VERSION)"`.  If the tag is
   missing, create it before doing anything else.
 - Always prompt the user to push: `git push origin --tags`.


### PR DESCRIPTION
## Summary
- The Releases section was internally inconsistent: the bump-subject rule says "no em dash" but the tag-message example uses one.
- Historical tags (v0.20.7-9) and the bump-subject rule both use `--`, so the em dash on the tag line is the typo.

## Changes
- `.claude/CLAUDE.md` (symlinked from `AGENTS.md`): change `v$VERSION — summary` to `v$VERSION -- summary` in the tag-message example.

## Test plan
- [ ] `git log --format=%(taggername)%n%(subject) v0.20.7..v0.20.12` — every tag now uses `--` consistently (after the v0.20.10/11/12 catch-up tags are pushed).
- [ ] No code paths affected; doc-only.