### PR TITLE
Build agent image in cmd_post_process

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -74,6 +74,49 @@ rm_docker_dir() {
         || rm -rf "$dir" 2>/dev/null || true
 }
 
+# Compute the comma-separated SWARM_AGENTS build-arg from a config:
+# the union of every agent group's driver and the post-process driver.
+# Used as a Dockerfile build-arg to gate per-CLI install layers; missing
+# a driver here is what produces "command not found" inside the agent.
+compute_swarm_agents() {
+    local cfg="$1"
+    local default_drv seen=" " out="" drv
+    default_drv=$(jq -r '.driver // "claude-code"' "$cfg")
+    while IFS= read -r drv; do
+        [ -z "$drv" ] && drv="$default_drv"
+        [[ "$seen" == *" $drv "* ]] && continue
+        seen+="$drv "
+        out="${out:+${out},}${drv}"
+    done < <(jq -r '.agents[]? | (.driver // "")' "$cfg")
+    local pp_drv
+    pp_drv=$(jq -r '.post_process.driver // .driver // "claude-code"' "$cfg")
+    if [ -n "$pp_drv" ] && [[ "$seen" != *" $pp_drv "* ]]; then
+        out="${out:+${out},}${pp_drv}"
+    fi
+    printf '%s' "$out"
+}
+
+# Build (or rebuild) the agent image with build-args derived from the current
+# config.  Docker's layer cache makes this a no-op when the args and Dockerfile
+# haven't changed; when the driver set or pinned CLI versions change the cache
+# invalidates correctly and the right install layer re-runs.  Called by
+# cmd_start *and* cmd_post_process so a standalone post-process invocation
+# never reuses an image built for a different driver set (which silently
+# produces exit-127 on first session -- see harness's `agent exited with code
+# 127` retry path).
+build_image() {
+    local swarm_agents cc_version codex_version
+    swarm_agents=$(compute_swarm_agents "$CONFIG_FILE")
+    cc_version=$(jq -r '.claude_code_version // empty' "$CONFIG_FILE" 2>/dev/null || true)
+    codex_version=$(jq -r '.codex_cli_version // empty' "$CONFIG_FILE" 2>/dev/null || true)
+    echo "--- Building agent image (agents: ${swarm_agents}) ---"
+    docker build -t "$IMAGE_NAME" \
+        --build-arg "SWARM_AGENTS=${swarm_agents}" \
+        ${cc_version:+--build-arg "CLAUDE_CODE_VERSION=${cc_version}"} \
+        ${codex_version:+--build-arg "CODEX_CLI_VERSION=${codex_version}"} \
+        -f "$SWARM_DIR/Dockerfile" "$SWARM_DIR"
+}
+
 CONFIG_FILE="${SWARM_CONFIG:-}"
 if [ -z "$CONFIG_FILE" ] && [ -f "$REPO_ROOT/swarm.json" ]; then
     CONFIG_FILE="$REPO_ROOT/swarm.json"
@@ -242,32 +285,7 @@ cmd_start() {
         exit 1
     fi
 
-    # Derive the set of agent CLIs to install from referenced drivers.
-    local _swarm_agents=""
-    local _seen_agents=" "
-    while IFS='|' read -r _ _ _ _ _ _ _ _ _ _drv; do
-        _drv="${_drv:-${SWARM_DRIVER_DEFAULT}}"
-        [[ "$_seen_agents" == *" $_drv "* ]] && continue
-        _seen_agents+="$_drv "
-        _swarm_agents="${_swarm_agents:+${_swarm_agents},}${_drv}"
-    done < "$AGENTS_CFG"
-    local _pp_drv
-    _pp_drv=$(jq -r '.post_process.driver // .driver // "claude-code"' "$CONFIG_FILE" 2>/dev/null || true)
-    if [[ "$_seen_agents" != *" $_pp_drv "* ]]; then
-        _swarm_agents="${_swarm_agents:+${_swarm_agents},}${_pp_drv}"
-    fi
-
-    local _cc_version
-    _cc_version=$(jq -r '.claude_code_version // empty' "$CONFIG_FILE" 2>/dev/null || true)
-    local _codex_cli_version
-    _codex_cli_version=$(jq -r '.codex_cli_version // empty' "$CONFIG_FILE" 2>/dev/null || true)
-
-    echo "--- Building agent image (agents: ${_swarm_agents}) ---"
-    docker build -t "$IMAGE_NAME" \
-        --build-arg "SWARM_AGENTS=${_swarm_agents}" \
-        ${_cc_version:+--build-arg "CLAUDE_CODE_VERSION=${_cc_version}"} \
-        ${_codex_cli_version:+--build-arg "CODEX_CLI_VERSION=${_codex_cli_version}"} \
-        -f "$SWARM_DIR/Dockerfile" "$SWARM_DIR"
+    build_image
 
     # Build mirror volume args from discovered submodules.
     git submodule foreach --quiet 'echo "$name"' | while read -r name; do
@@ -490,6 +508,8 @@ cmd_post_process() {
         git -C "$BARE_REPO" config core.sharedRepository world
         chmod -R a+rwX "$BARE_REPO"
     fi
+
+    build_image
 
     local NAME="${IMAGE_NAME}-post"
     docker rm -f "$NAME" 2>/dev/null || true

--- a/launch.sh
+++ b/launch.sh
@@ -212,7 +212,7 @@ cmd_start() {
     while IFS='|' read -r name gitdir; do
         safe_name="${name//\//_}"
         mirror="/tmp/${PROJECT}-mirror-${safe_name}.git"
-        rm -rf "$mirror"
+        rm_docker_dir "$mirror"
         echo "--- Mirroring submodule: ${name} ---"
         git clone --bare "$gitdir" "$mirror"
         chmod -R a+rwX "$mirror"

--- a/tests/test_launch.sh
+++ b/tests/test_launch.sh
@@ -1441,6 +1441,156 @@ rm -rf "$_bp_local" "$_bp_bare"
 
 # ============================================================
 echo ""
+echo "=== 38. compute_swarm_agents helper (live function from launch.sh) ==="
+
+# Source the function from launch.sh so the regression net follows the
+# real helper, not a mirror.  compute_swarm_agents has no globals
+# beyond jq, so extracting and sourcing it is safe.  Catches any
+# refactor that breaks the SWARM_AGENTS build-arg union.
+_LAUNCH_SH="$TESTS_DIR/../launch.sh"
+_EXTRACTED="$TMPDIR/compute_swarm_agents.sh"
+awk '/^compute_swarm_agents\(\)[[:space:]]*\{/ { p = 1 }
+     p { print }
+     p && /^\}[[:space:]]*$/ { exit }' \
+    "$_LAUNCH_SH" > "$_EXTRACTED"
+# shellcheck source=/dev/null
+source "$_EXTRACTED"
+
+assert_eq "function defined" "function" \
+    "$(type -t compute_swarm_agents)"
+
+cat > "$TMPDIR/csa_default.json" <<'EOF'
+{ "prompt": "p.md",
+  "agents": [{ "count": 2, "model": "claude-opus-4-6" }] }
+EOF
+assert_eq "default driver -> claude-code" "claude-code" \
+    "$(compute_swarm_agents "$TMPDIR/csa_default.json")"
+
+cat > "$TMPDIR/csa_codex.json" <<'EOF'
+{ "prompt": "p.md",
+  "driver": "codex-cli",
+  "agents": [{ "count": 1, "model": "gpt-5" }] }
+EOF
+assert_eq "codex-only top-level driver" "codex-cli" \
+    "$(compute_swarm_agents "$TMPDIR/csa_codex.json")"
+
+cat > "$TMPDIR/csa_mixed.json" <<'EOF'
+{ "prompt": "p.md",
+  "agents": [
+    { "count": 1, "model": "gpt-5",            "driver": "codex-cli"   },
+    { "count": 2, "model": "claude-opus-4-6",  "driver": "claude-code" }
+  ] }
+EOF
+assert_eq "mixed drivers (group order preserved)" \
+    "codex-cli,claude-code" \
+    "$(compute_swarm_agents "$TMPDIR/csa_mixed.json")"
+
+cat > "$TMPDIR/csa_dedup.json" <<'EOF'
+{ "prompt": "p.md",
+  "driver": "gemini-cli",
+  "agents": [
+    { "count": 1, "model": "gemini-2.5-pro" },
+    { "count": 1, "model": "gemini-3-flash" }
+  ] }
+EOF
+assert_eq "dedup same driver across groups" "gemini-cli" \
+    "$(compute_swarm_agents "$TMPDIR/csa_dedup.json")"
+
+# Exact scenario from the PR description: codex agents with a
+# claude-code post-processor.  Without rebuilding in
+# cmd_post_process the post container would inherit a claude-less
+# image and exit 127 on first session.  This assertion locks in
+# the union the build-arg has to express to install both CLIs.
+cat > "$TMPDIR/csa_pp_split.json" <<'EOF'
+{ "prompt": "p.md",
+  "driver": "codex-cli",
+  "agents": [{ "count": 1, "model": "gpt-5" }],
+  "post_process": { "prompt": "r.md", "driver": "claude-code" } }
+EOF
+assert_eq "codex agents + claude-code pp -> union" \
+    "codex-cli,claude-code" \
+    "$(compute_swarm_agents "$TMPDIR/csa_pp_split.json")"
+
+cat > "$TMPDIR/csa_pp_same.json" <<'EOF'
+{ "prompt": "p.md",
+  "agents": [{ "count": 1, "model": "claude-opus-4-6" }],
+  "post_process": { "prompt": "r.md" } }
+EOF
+assert_eq "pp default driver matches agents -> no dup" "claude-code" \
+    "$(compute_swarm_agents "$TMPDIR/csa_pp_same.json")"
+
+cat > "$TMPDIR/csa_pp_inherit.json" <<'EOF'
+{ "prompt": "p.md",
+  "driver": "gemini-cli",
+  "agents": [{ "count": 1, "model": "gemini-2.5-pro" }],
+  "post_process": { "prompt": "r.md" } }
+EOF
+assert_eq "pp inherits top-level driver -> single" "gemini-cli" \
+    "$(compute_swarm_agents "$TMPDIR/csa_pp_inherit.json")"
+
+cat > "$TMPDIR/csa_empty_group_drv.json" <<'EOF'
+{ "prompt": "p.md",
+  "driver": "codex-cli",
+  "agents": [{ "count": 1, "model": "gpt-5", "driver": "" }] }
+EOF
+assert_eq "empty per-group driver falls back to top-level" "codex-cli" \
+    "$(compute_swarm_agents "$TMPDIR/csa_empty_group_drv.json")"
+
+# ============================================================
+echo ""
+echo "=== 39. build_image is wired into both cmd_start and cmd_post_process ==="
+
+# The PR #96 contract: a standalone post-process invocation must
+# rebuild the image with build-args derived from its own config so
+# the layer cache invalidates correctly when the driver set differs
+# from a prior cmd_start.  Catches accidental removal of either
+# call site.
+_call_sites=$(grep -cE '^[[:space:]]+build_image[[:space:]]*$' \
+    "$_LAUNCH_SH" || true)
+assert_eq "build_image has 2 call sites" "2" "$_call_sites"
+
+_pp_calls=$(awk '
+    /^cmd_post_process\(\)[[:space:]]*\{/ { p = 1; next }
+    p && /^\}[[:space:]]*$/ { p = 0 }
+    p && /^[[:space:]]+build_image[[:space:]]*$/ { c++ }
+    END { print c + 0 }
+' "$_LAUNCH_SH")
+assert_eq "cmd_post_process calls build_image" "1" "$_pp_calls"
+
+_start_calls=$(awk '
+    /^cmd_start\(\)[[:space:]]*\{/ { p = 1; next }
+    p && /^\}[[:space:]]*$/ { p = 0 }
+    p && /^[[:space:]]+build_image[[:space:]]*$/ { c++ }
+    END { print c + 0 }
+' "$_LAUNCH_SH")
+assert_eq "cmd_start calls build_image" "1" "$_start_calls"
+
+# build_image must thread both the SWARM_AGENTS union and the
+# version pins; missing any of these would silently produce a
+# stale image.  Pinning the function body structurally is cheaper
+# than spinning up Docker.
+_bi_body=$(awk '
+    /^build_image\(\)[[:space:]]*\{/ { p = 1 }
+    p { print }
+    p && /^\}[[:space:]]*$/ { exit }
+' "$_LAUNCH_SH")
+assert_eq "build_image derives SWARM_AGENTS via compute_swarm_agents" \
+    "1" \
+    "$(printf '%s\n' "$_bi_body" \
+        | grep -cE 'compute_swarm_agents[[:space:]]+"\$CONFIG_FILE"' \
+        || true)"
+assert_eq "build_image forwards SWARM_AGENTS build-arg" "1" \
+    "$(printf '%s\n' "$_bi_body" \
+        | grep -cE -- '--build-arg "SWARM_AGENTS=' || true)"
+assert_eq "build_image forwards CLAUDE_CODE_VERSION build-arg" "1" \
+    "$(printf '%s\n' "$_bi_body" \
+        | grep -cE -- '--build-arg "CLAUDE_CODE_VERSION=' || true)"
+assert_eq "build_image forwards CODEX_CLI_VERSION build-arg" "1" \
+    "$(printf '%s\n' "$_bi_body" \
+        | grep -cE -- '--build-arg "CODEX_CLI_VERSION=' || true)"
+
+# ============================================================
+echo ""
 echo "==============================="
 echo "  ${PASS} passed, ${FAIL} failed"
 echo "==============================="


### PR DESCRIPTION
## Summary
Fixes an edge case that showed when trying to use a separate claude-code post-processor after the image was built for a codex-only config. The Docker layer cache wasn't picked up -- because the post-process path never called `docker build` at all -- so the post container inherited a claude-less image and the harness exited 127 on first session, needing manual `docker build` intervention to recover.

`cmd_post_process` now builds the image from the active config before launching, mirroring `cmd_start`. Build args are derived from the same config the container will use, so when the driver set changes the layer cache invalidates correctly and the right install layer re-runs; when it hasn't changed, the build is a no-op.

## Changes
- `launch.sh`: factor `compute_swarm_agents` (driver set from a config) and `build_image` (build with derived args) out of `cmd_start`, and call `build_image` from `cmd_post_process`.
- `launch.sh`: drive-by, switch the submodule mirror cleanup in `cmd_start` to `rm_docker_dir` so it works when a prior container left UID-mismatched files behind.

## Self-review checklist
<!-- Check all that apply before requesting review. -->
- [x] This PR addresses a **single concern** ([why?](https://blog.ploeh.dk/2015/01/15/10-tips-for-better-pull-requests/#2-do-only-one-thing)). If it covers multiple independent changes, I've split them into separate PRs.

## Test plan

Using two configs with identical prompts, having the agent drivers as the only difference (`swarm-codex.json` and `swarm-claude-code.json`):
- [x] Build with `swarm-codex.json`, then run post-process against `swarm-claude-code.json` -- image rebuilds with `claude-code` and the post container reaches a real session.
- [x] Re-run post-process with no config change -- build is a cache hit, install layer does not re-run.
- [x] `launch.sh start` against an unchanged config -- behavior identical to before.