### PR TITLE
Guard harvest against stale-bare poisoning

### DIFF
--- a/harvest.sh
+++ b/harvest.sh
@@ -48,6 +48,28 @@ echo "--- Fetching agent-work ---"
 git remote add "$REMOTE_NAME" "$BARE_REPO"
 git fetch --no-recurse-submodules "$REMOTE_NAME" agent-work
 
+# Guard against stale-bare poisoning: agent-work must descend from HEAD,
+# otherwise merging it would re-introduce ancestors not in HEAD's history
+# (e.g. commits removed by an upstream force-push that the bare repo did
+# not see).
+if ! git merge-base --is-ancestor HEAD "$REMOTE_NAME/agent-work"; then
+    echo "" >&2
+    echo "ERROR: $REMOTE_NAME/agent-work does not descend from HEAD." >&2
+    echo "  HEAD:       $(git rev-parse --short HEAD)" >&2
+    echo "  agent-work: $(git rev-parse --short "$REMOTE_NAME/agent-work")" >&2
+    echo "" >&2
+    echo "The bare repo at ${BARE_REPO} holds a branch that diverged from" >&2
+    echo "the current branch. This usually means upstream history was" >&2
+    echo "rewritten (e.g. force-push) but the bare repo still has the old" >&2
+    echo "ancestry. Merging would re-introduce removed commits." >&2
+    echo "" >&2
+    echo "Resolve by wiping and recreating the bare repo:" >&2
+    echo "  rm -rf ${BARE_REPO}" >&2
+    echo "  ./launch.sh ...   # recreates the bare from current HEAD" >&2
+    git remote remove "$REMOTE_NAME"
+    exit 1
+fi
+
 COMMIT_LOG=$(git log --oneline "$REMOTE_NAME/agent-work" ^HEAD)
 NEW_COMMITS=$(echo "$COMMIT_LOG" | grep -c . || true)
 echo ""

--- a/tests/test_harvest.sh
+++ b/tests/test_harvest.sh
@@ -10,9 +10,11 @@ TMPDIR=$(mktemp -d)
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 HARVEST_SH="$REPO_ROOT/harvest.sh"
 HARVEST_BARE=""
+GUARD_BARE=""
 cleanup() {
     rm -rf "$TMPDIR"
     [ -n "${HARVEST_BARE:-}" ] && rm -rf "$HARVEST_BARE"
+    [ -n "${GUARD_BARE:-}" ]   && rm -rf "$GUARD_BARE"
 }
 trap cleanup EXIT
 
@@ -271,6 +273,97 @@ set -e
 assert_eq "guarded pipe exits 0" "0" "$guarded_rc"
 assert_eq "guarded pipe continues past the preview" "true" \
     "$(grep -q '^REACHED_AFTER_PIPE$' "$TMPDIR/guarded.out" \
+        && echo true || echo false)"
+
+# ============================================================
+echo ""
+echo "=== 9. Behavioural: harvest.sh refuses divergent bare ==="
+
+# Reproduces issue #97: an upstream history rewrite (force-push,
+# rebase) leaves the bare's agent-work pointing at a tip whose
+# ancestry no longer matches the working tree's HEAD.  Without
+# the guard, harvest.sh silently 3-way-merges and re-introduces
+# commits the operator already removed; with the guard it aborts
+# with a clear remediation.
+
+GUARD_PROJECT="swarmtest-harvest-guard-$$"
+GUARD_WORK="$TMPDIR/$GUARD_PROJECT"
+GUARD_BARE="/tmp/${GUARD_PROJECT}-upstream.git"
+GUARD_AGENT="$TMPDIR/harvest-guard-agent"
+
+rm -rf "$GUARD_WORK" "$GUARD_BARE" "$GUARD_AGENT"
+mkdir -p "$GUARD_WORK"
+git init -q "$GUARD_WORK"
+cd "$GUARD_WORK"
+git -c user.name=test -c user.email=t@t -c commit.gpgsign=false \
+    commit -q --allow-empty -m A
+git -c user.name=test -c user.email=t@t -c commit.gpgsign=false \
+    commit -q --allow-empty -m B
+git -c user.name=test -c user.email=t@t -c commit.gpgsign=false \
+    commit -q --allow-empty -m C
+
+git clone -q --bare "$GUARD_WORK" "$GUARD_BARE"
+# Move bare's agent-work back to B (HEAD~1) and have an "agent"
+# commit on top of B.  agent-work then descends from B but not
+# from HEAD (=C), so the guard's --is-ancestor check fails.
+git -C "$GUARD_BARE" branch -f agent-work HEAD~1
+
+git clone -q "$GUARD_BARE" "$GUARD_AGENT"
+cd "$GUARD_AGENT"
+git checkout -q agent-work
+git -c user.name=agent -c user.email=a@a -c commit.gpgsign=false \
+    commit -q --allow-empty -m "agent commit on sibling"
+git push -q origin agent-work
+rm -rf "$GUARD_AGENT"
+
+cd "$GUARD_WORK"
+HEAD_BEFORE=$(git rev-parse HEAD)
+set +e
+guard_output=$(bash "$HARVEST_SH" 2>&1)
+guard_rc=$?
+set -e
+HEAD_AFTER=$(git rev-parse HEAD)
+
+assert_eq "guard exits non-zero on divergent bare" "true" \
+    "$([ "$guard_rc" -ne 0 ] && echo true || echo false)"
+assert_eq "guard prints the diagnostic line" "true" \
+    "$(printf '%s\n' "$guard_output" \
+        | grep -q 'does not descend from HEAD' \
+        && echo true || echo false)"
+assert_eq "guard names short HEAD in diagnostic" "true" \
+    "$(printf '%s\n' "$guard_output" \
+        | grep -qE "HEAD:[[:space:]]+${HEAD_BEFORE:0:7}" \
+        && echo true || echo false)"
+assert_eq "guard names the bare path in remediation" "true" \
+    "$(printf '%s\n' "$guard_output" \
+        | grep -qF "rm -rf ${GUARD_BARE}" \
+        && echo true || echo false)"
+assert_eq "no merge commit produced" "$HEAD_BEFORE" "$HEAD_AFTER"
+assert_eq "_agent-harvest remote cleaned up after failure" "" \
+    "$(git remote | grep -E '^_agent-harvest$' || true)"
+
+# Sanity check the happy path: when agent-work descends from
+# HEAD again, the same harvest.sh invocation succeeds.  Catches
+# a regression where the guard accidentally rejects valid runs.
+git -C "$GUARD_BARE" branch -f agent-work "$HEAD_BEFORE"
+git clone -q "$GUARD_BARE" "$GUARD_AGENT"
+cd "$GUARD_AGENT"
+git checkout -q agent-work
+git -c user.name=agent -c user.email=a@a -c commit.gpgsign=false \
+    commit -q --allow-empty -m "agent fast-forward"
+git push -q origin agent-work
+rm -rf "$GUARD_AGENT"
+
+cd "$GUARD_WORK"
+set +e
+ff_output=$(bash "$HARVEST_SH" 2>&1)
+ff_rc=$?
+set -e
+
+assert_eq "fast-forward harvest still exits 0" "0" "$ff_rc"
+assert_eq "fast-forward shows new commit header" "true" \
+    "$(printf '%s\n' "$ff_output" \
+        | grep -q '^1 new commits on agent-work:' \
         && echo true || echo false)"
 
 # ============================================================


### PR DESCRIPTION
#### Summary
- Refuse to merge `_agent-harvest/agent-work` when it does not descend from `HEAD`.
- Closes the loop where a stale bare repo silently re-injects deleted commits after an upstream force-push.
- Closes #97 

#### Changes
- `harvest.sh`: before `git merge`, run `git merge-base --is-ancestor HEAD "$REMOTE_NAME/agent-work"`. On failure, print divergent SHAs, instruct operator to wipe `/tmp/<project>-upstream.git` and re-run `launch.sh`, remove the temporary remote, and exit `1`. The check is generic — no hard-coded branch names — so it covers `workflow/master`, `master`, and any custom branch.

#### Test plan
- [x] `tests/test_harvest.sh` — all 20 existing assertions still pass.
- [ ] Add a regression test: stage a bare repo whose `agent-work` does not descend from the work-tree HEAD, run `harvest.sh`, assert non-zero exit and that no merge commit is created. (Follow-up.)
- [ ] `tests/test.sh --all` — full suite.
- [ ] `shellcheck -s bash harvest.sh` — clean (only SC2016 / SC2317 info-level allowed per project rules).
- [ ] Manual: set up a divergent bare, run harvest, confirm it aborts with the new error.
- [ ] Manual: with a fresh bare and clean HEAD, confirm normal harvest still merges as before.

#### Follow-ups (not in this PR)
- `CHANGELOG.md` entry under a new `0.20.14` heading.
- `VERSION` bump to `0.20.14` in a separate commit (per project release-discipline rule: version-bump commits touch only `VERSION` and `CHANGELOG.md`).
- Regression test in `tests/test_harvest.sh` for the new guard.