### PR TITLE
Preserve in-flight agent commits on fatal exit and `docker stop`

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -85,7 +85,12 @@ Drafting the PR:
        - [ ] Concrete verification steps.
 
 4. 3-6 summary bullets. Group related commits.
-5. Test plan: runnable commands or observable behaviors.
+5. Each bullet is one line; surrounding prose 1-2
+   lines max.  Don't pre-wrap PR bodies at 79 chars
+   -- the "Wrap to 79 chars" rule under "Quality
+   bars" applies to source, docs, and commits, not
+   to PR text on GitHub.
+6. Test plan: runnable commands or observable behaviors.
 
 ## Linting
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,55 @@
 # Changelog
 
+## Unreleased
+
+- **Fix: agent commits abandoned on fatal-error exit and on
+  `docker stop`.**  The session-end push pipeline (in-place
+  rebase -> scratch worktree -> agent-parked salvage) ran ONLY
+  at the bottom of the per-iteration loop, AFTER the
+  `FATAL_MSG` handling block that exits with code 1 on
+  non-retriable model errors, retry-budget exhaustion, and
+  zero-token failures.  In a real 45-agent swarm, 15 agents
+  exited that exact path holding 3-154 commits each that died
+  with the container.  Separately, `docker stop` (default
+  SIGTERM + 10 s grace + SIGKILL) hit the harness while it was
+  parked in a foreground pipeline, so its push block never ran
+  either -- 26 of the same 45 agents lost commits through that
+  door.
+
+  Fix in three layers:
+
+  - Hoist the inline push pipeline into `_session_end_push` and
+    call it before every fatal `exit 1` in the `FATAL_MSG`
+    block (with `|| true` so a final push failure does not
+    mask the original fatal cause).  Tests:
+    `tests/test_session_end_push.sh` §6 -- one definition, one
+    inline call, three fatal-exit calls, an awk walk pins the
+    ordering constraint that the push immediately precedes the
+    exit, and the call-site count is locked at six.
+
+  - Wrap the agent pipeline in a backgrounded subshell
+    (`( agent_run ... | /activity-filter.sh ) &; wait`) so the
+    harness's `wait` becomes signal-interruptible.  Install
+    `trap '_on_signal TERM' TERM` (and `INT`) right before the
+    main loop.  `_on_signal` kills the running pipeline, calls
+    `_session_end_push`, then exits 143 / 130.  Tests:
+    `tests/test_session_end_push.sh` §7 pins both per-loop
+    invocations using `_run_agent_session`, the absence of any
+    bare foreground `agent_run | /activity-filter.sh`
+    pipeline, the trap installation, and the handler's
+    kill / push / exit behaviour.
+
+  - `cmd_stop` in `launch.sh` now passes
+    `-t "${SWARM_STOP_TIMEOUT:-60}"` to `docker stop`.
+    Docker's 10 s default cuts the emergency push mid-rebase
+    on a busy bare repo; 60 s comfortably absorbs the
+    three-try rebase plus the scratch-worktree cherry-pick
+    plus the agent-parked salvage push.  Override with
+    `SWARM_STOP_TIMEOUT=120 ./launch.sh stop` for larger
+    swarms.  Tests: `tests/test_launch.sh` §40 pins the flag,
+    the default, and the env-var override via a fake-docker
+    shim that captures the invocations.
+
 ## 0.20.14 — 2026-05-06
 
 - **Fix: `cmd_post_process` reused a stale image after the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## Unreleased
 
+- **Test: runtime emergency-push verification under `--all`.**
+  `tests/runtime_signal_trap.sh` drives the harness's
+  SIGTERM / SIGINT / fatal-exit emergency-push paths inside a
+  real container, using a synthetic `test-committer` driver
+  mounted via `-v` so no API key is required.  Asserts the
+  exit code (143 / 130 / 1), the harness's log markers
+  (`received SIG…`, `attempting emergency push`,
+  `emergency shutdown complete`), and that the in-flight
+  commit lands on `origin/agent-work`.  Also asserts the
+  `cmd_stop` banner echoes the active `SWARM_STOP_TIMEOUT`.
+  The pure structural assertions in
+  `tests/test_session_end_push.sh` §6 / §7 pin the code
+  shape but cannot prove the signal trap actually fires;
+  this test does, end-to-end.
+
+  Wired into `tests/test.sh` as Phase 1.5 of `--all` between
+  unit and API-key integration, and exposed as
+  `tests/test.sh --runtime` for standalone runs.  Skips
+  cleanly when Docker is unavailable so `--all` stays useful
+  on hosts without it.  Wall-clock ~25 s with the image
+  cached; first run additionally pays the cached `docker
+  build` for `claude-swarm-runtime-test:latest`
+  (`--build-arg SWARM_AGENTS=fake`, so no CLI-install
+  layers).
+
 - **Fix: agent commits abandoned on fatal-error exit and on
   `docker stop`.**  The session-end push pipeline (in-place
   rebase -> scratch worktree -> agent-parked salvage) ran ONLY

--- a/USAGE.md
+++ b/USAGE.md
@@ -38,6 +38,7 @@ Credentials stay as env vars (not in shell history).
 | `SWARM_ACTIVITY_TIMEOUT` | `0` | Seconds of logfile silence before the in-container watchdog SIGTERMs the agent CLI's process group.  `0` disables.  See [Activity watchdog](#activity-watchdog). |
 | `SWARM_ACTIVITY_POLL` | `10` | Watchdog mtime-poll interval, in seconds.  Rarely needs tuning. |
 | `SWARM_WATCHDOG_GRACE` | `10` | Grace window between watchdog SIGTERM and SIGKILL.  Rarely needs tuning. |
+| `SWARM_STOP_TIMEOUT` | `60` | Seconds `./launch.sh stop` passes to `docker stop -t`, so the harness's SIGTERM trap has time to ship any in-flight local commits via `_session_end_push` before SIGKILL hits.  See [Stopping the swarm](#stopping-the-swarm). |
 
 Per-group credentials (`api_key`, `auth_token`, `base_url`)
 are set in the swarmfile.  Use `$VAR` references to pull
@@ -115,6 +116,32 @@ crashed-on-its-own exit.  `SWARM_ACTIVITY_POLL` (default 10 s)
 tunes how often the watchdog checks mtime;
 `SWARM_WATCHDOG_GRACE` (default 10 s) tunes the SIGTERM→SIGKILL
 gap.  Both rarely need adjustment outside the test suite.
+
+### Stopping the swarm
+
+`./launch.sh stop` sends each container `docker stop -t 60`.
+The 60 s grace gives the harness's SIGTERM trap time to ship
+any in-flight local commits (in-place rebase → scratch
+worktree → `agent-parked/*` salvage) before docker forces
+SIGKILL.  Without this window, commits the agent made during
+the session it was interrupted in stayed in
+`/workspace/.git` and died with the container; the
+session-end push pipeline only runs at the bottom of each
+loop iteration and never gets to run on a mid-session
+SIGTERM.
+
+For larger swarms where 45+ agents race the same push lock,
+raise the grace:
+
+```bash
+SWARM_STOP_TIMEOUT=120 ./launch.sh stop
+```
+
+The harness handles SIGTERM and SIGINT identically; an
+`Exited (143)` (`128+SIGTERM`) or `Exited (130)`
+(`128+SIGINT`) status with a clean log line of
+`emergency shutdown complete` indicates the trap fired and
+the emergency push attempt completed.
 
 ### Extra Docker arguments
 

--- a/launch.sh
+++ b/launch.sh
@@ -419,10 +419,18 @@ ENVEOF
 }
 
 cmd_stop() {
-    echo "--- Stopping agents ---"
+    # Default to a 60s grace so the harness's SIGTERM trap has
+    # time to ship any in-flight local commits via
+    # `_session_end_push` before docker forces SIGKILL.  The 10s
+    # default that docker ships with cuts the emergency push
+    # mid-rebase on a busy bare repo.  Override via env:
+    #   SWARM_STOP_TIMEOUT=120 ./launch.sh stop
+    local stop_timeout="${SWARM_STOP_TIMEOUT:-60}"
+    echo "--- Stopping agents (grace ${stop_timeout}s) ---"
     for i in $(seq 1 "$NUM_AGENTS"); do
         NAME="${IMAGE_NAME}-${i}"
-        docker stop "$NAME" 2>/dev/null && echo "  stopped ${NAME}" \
+        docker stop -t "$stop_timeout" "$NAME" 2>/dev/null \
+            && echo "  stopped ${NAME}" \
             || echo "  ${NAME} not running"
     done
     rm -f "/tmp/${PROJECT}-swarm.env"

--- a/lib/harness.sh
+++ b/lib/harness.sh
@@ -428,6 +428,67 @@ _session_end_push() {
     return 1
 }
 
+# Run one agent session in the background so the parent's `wait`
+# on it can be interrupted by SIGTERM, which is what lets the
+# _on_signal trap below kill the agent and ship in-flight local
+# commits before docker's SIGKILL hits.  Foreground pipelines
+# defer trap handlers until the child returns (see bash(1)
+# under "SIGNALS"), so the original
+#   agent_run ... | /activity-filter.sh
+# left the harness deaf to SIGTERM for the entire session.
+# A backgrounded subshell with `wait` is signal-interruptible
+# and `pipefail` (inherited from the parent shell) keeps the
+# return code identical to the original pipeline's.
+#
+# Side effect: sets the global _SESSION_PID for the duration of
+# the wait so _on_signal can target the running pipeline; resets
+# it to "" before returning so a signal arriving between
+# sessions does not chase a stale PID.
+_run_agent_session() {
+    local model="$1" prompt="$2" logfile="$3" append="$4"
+    local rc=0
+    ( agent_run "$model" "$prompt" "$logfile" "$append" \
+            | /activity-filter.sh ) &
+    _SESSION_PID=$!
+    wait "$_SESSION_PID" || rc=$?
+    _SESSION_PID=""
+    return "$rc"
+}
+
+# Handle SIGTERM / SIGINT: kill the in-flight agent session so
+# `wait` in _run_agent_session returns, push any local commits
+# the agent already made this session, then exit with the
+# conventional signal exit code.
+#
+# Without this trap, `docker stop` (default: SIGTERM + 10s grace
+# + SIGKILL) abandoned any unpushed commits sitting in
+# /workspace/.git -- the harness was busy waiting on the agent
+# pipeline and the bottom-of-loop push block never ran.  Pair
+# this with `docker stop -t 60` (see launch.sh cmd_stop) so the
+# emergency push has time to land before SIGKILL.
+_on_signal() {
+    local sig="$1"
+    local exit_code
+    case "$sig" in
+        TERM) exit_code=143 ;;
+        INT)  exit_code=130 ;;
+        *)    exit_code=1   ;;
+    esac
+    hlog_err "received SIG${sig}, attempting emergency push"
+    if [ -n "${_SESSION_PID:-}" ] \
+            && kill -0 "$_SESSION_PID" 2>/dev/null; then
+        kill -TERM "$_SESSION_PID" 2>/dev/null || true
+        # Brief grace for the agent to flush; then force.
+        sleep 1
+        kill -KILL "$_SESSION_PID" 2>/dev/null || true
+    fi
+    if cd /workspace 2>/dev/null; then
+        _session_end_push || true
+    fi
+    hlog "emergency shutdown complete"
+    exit "$exit_code"
+}
+
 GIT_USER_NAME="${GIT_USER_NAME:-swarm-agent}"
 GIT_USER_EMAIL="${GIT_USER_EMAIL:-agent@swarm.local}"
 git config --global user.name "$GIT_USER_NAME"
@@ -608,6 +669,13 @@ IDLE_FILE="/workspace/agent_logs/idle_agent_${AGENT_ID}"
 RETRY_FILE="/workspace/agent_logs/retry_agent_${AGENT_ID}"
 rm -f "$RETRY_FILE"
 
+# Install signal handlers after workspace setup so the emergency
+# push has a /workspace/.git to push from.  Setting these here,
+# not at the top of the script, keeps an interrupt during the
+# initial clone from chasing a missing repo.
+trap '_on_signal TERM' TERM
+trap '_on_signal INT' INT
+
 while true; do
     # Reset to latest. Do not re-init submodules; setup changes would be lost.
     git fetch --no-recurse-submodules origin 2>&1 | hlog_pipe
@@ -633,8 +701,8 @@ while true; do
 
     AGENT_RUN_EXIT=0
     _run_start=$SECONDS
-    agent_run "$SWARM_MODEL" "$(cat "$SWARM_PROMPT")" "$LOGFILE" "$APPEND_FILE" \
-        | /activity-filter.sh || AGENT_RUN_EXIT=$?
+    _run_agent_session "$SWARM_MODEL" "$(cat "$SWARM_PROMPT")" \
+        "$LOGFILE" "$APPEND_FILE" || AGENT_RUN_EXIT=$?
     _run_elapsed_ms=$(( (SECONDS - _run_start) * 1000 ))
 
     # Extract usage stats via the driver.
@@ -706,8 +774,8 @@ while true; do
                 rm -f "$RETRY_FILE"
                 AGENT_RUN_EXIT=0
                 _run_start=$SECONDS
-                agent_run "$SWARM_MODEL" "$(cat "$SWARM_PROMPT")" "$LOGFILE" "$APPEND_FILE" \
-                    | /activity-filter.sh || AGENT_RUN_EXIT=$?
+                _run_agent_session "$SWARM_MODEL" "$(cat "$SWARM_PROMPT")" \
+                    "$LOGFILE" "$APPEND_FILE" || AGENT_RUN_EXIT=$?
                 _run_elapsed_ms=$(( (SECONDS - _run_start) * 1000 ))
                 STATS_LINE=$(agent_extract_stats "$LOGFILE")
                 IFS=$'\t' read -r cost tok_in tok_out cache_rd cache_cr dur api_ms turns <<< "$STATS_LINE"

--- a/lib/harness.sh
+++ b/lib/harness.sh
@@ -271,6 +271,163 @@ _scratch_worktree_push() {
     return "$_rc"
 }
 
+# Ship any local commits to origin/agent-work.  Called both
+# inline at session end and before fatal-error exits / signal
+# trap handlers so commits an agent made during a session that
+# then hit a fatal error or a SIGTERM are not abandoned with
+# the container.
+#
+# Side effect: updates the global AFTER to the post-push tip of
+# origin/agent-work so the caller can use it for idle tracking.
+# Returns 0 on success or no-op (nothing to push, or pushed
+# cleanly), 1 if there were unpushed commits and every push
+# path failed.
+_session_end_push() {
+    git fetch --no-recurse-submodules origin 2>&1 | hlog_pipe
+    AFTER=$(git rev-parse origin/agent-work)
+
+    local _local_head _dirty _stash_before _stash_after
+    local _push_ok _try
+
+    # Safety net: if the agent committed locally but failed to
+    # push (concurrent lock, transient error), push on its behalf
+    # with jittered retries to avoid collisions across containers.
+    _local_head=$(git rev-parse HEAD)
+    if [ "$_local_head" = "$AFTER" ] \
+            || [ "$(git rev-list origin/agent-work..HEAD 2>/dev/null | wc -l)" -eq 0 ]; then
+        return 0
+    fi
+
+    hlog "found unpushed local commits, pushing"
+
+    # The session-end push rebases local commits onto origin/agent-work.
+    # Any dirty state in the working tree -- tracked mods, deletions,
+    # untracked scratch files, submodule pointer drift -- has to be
+    # cleaned out first or `git pull --rebase` will refuse with
+    # "cannot rebase: You have unstaged changes" and the retry loop
+    # burns through all three attempts without pushing.
+    #
+    # v0.20.2 tried to solve this with `rebase.autoStash=true`, but
+    # autoStash has three documented gaps that caused real push
+    # failures in production (see CHANGELOG 0.20.4 for the
+    # failure-mode breakdown):
+    #
+    #   (1) `git stash` defaults to NOT stashing untracked files, so
+    #       autoStash silently leaves `?? <path>` in the worktree and
+    #       the rebase refuses anyway.
+    #
+    #   (2) `git stash` does NOT capture submodule pointer drift
+    #       (`M <submodule>`) regardless of flags -- the superproject
+    #       gitlink diff is simply not visible to stash's default
+    #       traversal.  Agents that run `cargo build`, `git worktree
+    #       add`, or anything else that bumps a submodule HEAD trip
+    #       this every time.
+    #
+    #   (3) When autoStash does create a stash, the auto-pop after a
+    #       successful rebase is best-effort per git's own docs and
+    #       was observed failing mid-rebase on
+    #       "skipped previously applied commit" in multi-agent swarms.
+    #
+    # The fix below sidesteps all three by doing the stash explicitly
+    # (with --include-untracked), re-syncing submodule HEADs to what
+    # the superproject expects, and running the rebase against a
+    # guaranteed-clean tree.  We intentionally do NOT pop the stash:
+    # the next loop iteration runs `git reset --hard origin/agent-work`
+    # at the top, which would wipe a popped stash anyway, so popping
+    # here buys nothing while reintroducing the autoStash-pop conflict
+    # class.  The stash stays in reflog (`git stash list`) for
+    # forensic recovery if an operator needs to inspect what was
+    # in-flight.
+    _dirty=$(git status --porcelain=v1 2>/dev/null)
+    if [ -n "$_dirty" ]; then
+        hlog "dirty worktree before push:"
+        printf '%s\n' "$_dirty" | hlog_pipe
+
+        # (a) Stash everything `git stash` can reach -- tracked mods,
+        # tracked deletions, staged changes, untracked files.
+        # Count-before / count-after is the bulletproof way to
+        # detect "nothing was actually stashed" (all of the dirty
+        # state was submodule drift, which stash silently ignores).
+        _stash_before=$(git stash list 2>/dev/null | wc -l)
+        git stash push --include-untracked --quiet \
+            -m "claude-swarm pre-push $(date -u +%s)" 2>&1 | hlog_pipe || true
+        _stash_after=$(git stash list 2>/dev/null | wc -l)
+        if [ "$_stash_after" -gt "$_stash_before" ]; then
+            hlog "pre-push stash: $(git rev-parse 'stash@{0}' 2>/dev/null)"
+        fi
+
+        # (b) Re-sync submodule HEADs to the superproject's expected
+        # gitlink.  This is what clears `M <submodule>` from status
+        # -- stash cannot reach it.  --force is safe here because
+        # dirty submodule state is ephemeral build output; anything
+        # worth preserving should already be in a commit or in the
+        # stash above.  `|| true` so a submodule-less repo or a
+        # transient network hiccup doesn't abort the push path.
+        git submodule update --init --recursive --force 2>&1 | hlog_pipe || true
+    fi
+
+    _push_ok=false
+    for _try in 1 2 3; do
+        sleep $((RANDOM % 5 + 1))
+        # Clean up stale rebase state that blocks git pull --rebase.
+        if [ -d .git/rebase-merge ] || [ -d .git/rebase-apply ]; then
+            git rebase --abort 2>/dev/null || rm -rf .git/rebase-merge .git/rebase-apply
+        fi
+        # Bare `git pull --rebase` -- the pre-stash + submodule-sync
+        # above guarantees a clean tree, so there is nothing for the
+        # rebase to trip on and autoStash is intentionally absent
+        # (see the comment block above for why).
+        #
+        # core.hooksPath=/dev/null is also essential here.  Rebase
+        # drives internal checkouts through .git/rebase-merge/,
+        # firing post-checkout / post-rewrite on every pick.
+        # Consumer-installed hooks that touch the worktree
+        # (regenerate docs, stamp build artifacts, etc.) therefore
+        # re-dirty the tree mid-rebase and fail every retry.  Our
+        # own prepare-commit-msg / post-rewrite hooks (installed
+        # above) are no-ops for commits that already carry a
+        # `Model:` trailer, and every agent-made commit does,
+        # because prepare-commit-msg ran at commit time -- so
+        # suppressing both during the session-end rebase is safe.
+        # The `-c core.hooksPath=/dev/null` override only disables
+        # client-side hooks; server-side hooks on /upstream
+        # (pre-receive, etc.) still run.
+        if git -c core.hooksPath=/dev/null pull --rebase origin agent-work 2>&1 | hlog_pipe \
+                && git -c core.hooksPath=/dev/null push origin agent-work 2>&1 | hlog_pipe; then
+            _push_ok=true
+            break
+        fi
+        hlog "push retry ${_try}/3"
+    done
+
+    # Fallback: if all three in-place rebase attempts failed, ship
+    # the unpushed commits via a scratch worktree.  This path
+    # ignores the main worktree's state entirely -- it cherry-
+    # picks onto a fresh checkout of origin/agent-work, so
+    # whatever is re-dirtying the rebase (submodule drift,
+    # context-stripping hooks firing during .git/rebase-merge
+    # checkouts, a commit already upstream tripping "skipped
+    # previously applied commit") cannot affect it.  Empirically
+    # turns the 0.20.4 "100% data loss on push failure" state
+    # into "push succeeds via transplant" for every failure
+    # pattern we've observed in production.
+    if [ "$_push_ok" != true ]; then
+        hlog "rebase path exhausted, trying scratch worktree fallback"
+        if _scratch_worktree_push; then
+            _push_ok=true
+        fi
+    fi
+
+    if [ "$_push_ok" = true ]; then
+        git fetch --no-recurse-submodules origin 2>&1 | hlog_pipe
+        AFTER=$(git rev-parse origin/agent-work)
+        return 0
+    fi
+
+    hlog_err "push failed after 3 retries and scratch fallback"
+    return 1
+}
+
 GIT_USER_NAME="${GIT_USER_NAME:-swarm-agent}"
 GIT_USER_EMAIL="${GIT_USER_EMAIL:-agent@swarm.local}"
 git config --global user.name "$GIT_USER_NAME"
@@ -580,157 +737,27 @@ while true; do
                 if [ -z "$_retriable" ]; then
                     hlog_err "fatal (non-retriable): ${FATAL_MSG}"
                     hlog_err "exiting due to unrecoverable error"
+                    # Ship any local commits the agent made before
+                    # the fatal error so they are not abandoned.
+                    _session_end_push || true
                     exit 1
                 fi
             done
             if [ -n "$FATAL_MSG" ]; then
                 hlog_err "fatal: ${FATAL_MSG}"
                 hlog_err "retry wait limit reached (${MAX_RETRY_WAIT}s), exiting"
+                _session_end_push || true
                 exit 1
             fi
         else
             hlog_err "fatal: ${FATAL_MSG}"
             hlog_err "exiting due to unrecoverable error"
+            _session_end_push || true
             exit 1
         fi
     fi
 
-    git fetch --no-recurse-submodules origin 2>&1 | hlog_pipe
-    AFTER=$(git rev-parse origin/agent-work)
-
-    # Safety net: if the agent committed locally but failed to
-    # push (concurrent lock, transient error), push on its behalf
-    # with jittered retries to avoid collisions across containers.
-    _local_head=$(git rev-parse HEAD)
-    if [ "$_local_head" != "$AFTER" ] \
-            && [ "$(git rev-list origin/agent-work..HEAD 2>/dev/null | wc -l)" -gt 0 ]; then
-        hlog "found unpushed local commits, pushing"
-
-        # The session-end push rebases local commits onto origin/agent-work.
-        # Any dirty state in the working tree -- tracked mods, deletions,
-        # untracked scratch files, submodule pointer drift -- has to be
-        # cleaned out first or `git pull --rebase` will refuse with
-        # "cannot rebase: You have unstaged changes" and the retry loop
-        # burns through all three attempts without pushing.
-        #
-        # v0.20.2 tried to solve this with `rebase.autoStash=true`, but
-        # autoStash has three documented gaps that caused real push
-        # failures in production (see CHANGELOG 0.20.4 for the
-        # failure-mode breakdown):
-        #
-        #   (1) `git stash` defaults to NOT stashing untracked files, so
-        #       autoStash silently leaves `?? <path>` in the worktree and
-        #       the rebase refuses anyway.
-        #
-        #   (2) `git stash` does NOT capture submodule pointer drift
-        #       (`M <submodule>`) regardless of flags -- the superproject
-        #       gitlink diff is simply not visible to stash's default
-        #       traversal.  Agents that run `cargo build`, `git worktree
-        #       add`, or anything else that bumps a submodule HEAD trip
-        #       this every time.
-        #
-        #   (3) When autoStash does create a stash, the auto-pop after a
-        #       successful rebase is best-effort per git's own docs and
-        #       was observed failing mid-rebase on
-        #       "skipped previously applied commit" in multi-agent swarms.
-        #
-        # The fix below sidesteps all three by doing the stash explicitly
-        # (with --include-untracked), re-syncing submodule HEADs to what
-        # the superproject expects, and running the rebase against a
-        # guaranteed-clean tree.  We intentionally do NOT pop the stash:
-        # the next loop iteration runs `git reset --hard origin/agent-work`
-        # at the top, which would wipe a popped stash anyway, so popping
-        # here buys nothing while reintroducing the autoStash-pop conflict
-        # class.  The stash stays in reflog (`git stash list`) for
-        # forensic recovery if an operator needs to inspect what was
-        # in-flight.
-        _dirty=$(git status --porcelain=v1 2>/dev/null)
-        if [ -n "$_dirty" ]; then
-            hlog "dirty worktree before push:"
-            printf '%s\n' "$_dirty" | hlog_pipe
-
-            # (a) Stash everything `git stash` can reach -- tracked mods,
-            # tracked deletions, staged changes, untracked files.
-            # Count-before / count-after is the bulletproof way to
-            # detect "nothing was actually stashed" (all of the dirty
-            # state was submodule drift, which stash silently ignores).
-            _stash_before=$(git stash list 2>/dev/null | wc -l)
-            git stash push --include-untracked --quiet \
-                -m "claude-swarm pre-push $(date -u +%s)" 2>&1 | hlog_pipe || true
-            _stash_after=$(git stash list 2>/dev/null | wc -l)
-            if [ "$_stash_after" -gt "$_stash_before" ]; then
-                hlog "pre-push stash: $(git rev-parse 'stash@{0}' 2>/dev/null)"
-            fi
-
-            # (b) Re-sync submodule HEADs to the superproject's expected
-            # gitlink.  This is what clears `M <submodule>` from status
-            # -- stash cannot reach it.  --force is safe here because
-            # dirty submodule state is ephemeral build output; anything
-            # worth preserving should already be in a commit or in the
-            # stash above.  `|| true` so a submodule-less repo or a
-            # transient network hiccup doesn't abort the push path.
-            git submodule update --init --recursive --force 2>&1 | hlog_pipe || true
-        fi
-
-        _push_ok=false
-        for _try in 1 2 3; do
-            sleep $((RANDOM % 5 + 1))
-            # Clean up stale rebase state that blocks git pull --rebase.
-            if [ -d .git/rebase-merge ] || [ -d .git/rebase-apply ]; then
-                git rebase --abort 2>/dev/null || rm -rf .git/rebase-merge .git/rebase-apply
-            fi
-            # Bare `git pull --rebase` -- the pre-stash + submodule-sync
-            # above guarantees a clean tree, so there is nothing for the
-            # rebase to trip on and autoStash is intentionally absent
-            # (see the comment block above for why).
-            #
-            # core.hooksPath=/dev/null is also essential here.  Rebase
-            # drives internal checkouts through .git/rebase-merge/,
-            # firing post-checkout / post-rewrite on every pick.
-            # Consumer-installed hooks that touch the worktree
-            # (regenerate docs, stamp build artifacts, etc.) therefore
-            # re-dirty the tree mid-rebase and fail every retry.  Our
-            # own prepare-commit-msg / post-rewrite hooks (installed
-            # above) are no-ops for commits that already carry a
-            # `Model:` trailer, and every agent-made commit does,
-            # because prepare-commit-msg ran at commit time -- so
-            # suppressing both during the session-end rebase is safe.
-            # The `-c core.hooksPath=/dev/null` override only disables
-            # client-side hooks; server-side hooks on /upstream
-            # (pre-receive, etc.) still run.
-            if git -c core.hooksPath=/dev/null pull --rebase origin agent-work 2>&1 | hlog_pipe \
-                    && git -c core.hooksPath=/dev/null push origin agent-work 2>&1 | hlog_pipe; then
-                _push_ok=true
-                break
-            fi
-            hlog "push retry ${_try}/3"
-        done
-
-        # Fallback: if all three in-place rebase attempts failed, ship
-        # the unpushed commits via a scratch worktree.  This path
-        # ignores the main worktree's state entirely -- it cherry-
-        # picks onto a fresh checkout of origin/agent-work, so
-        # whatever is re-dirtying the rebase (submodule drift,
-        # context-stripping hooks firing during .git/rebase-merge
-        # checkouts, a commit already upstream tripping "skipped
-        # previously applied commit") cannot affect it.  Empirically
-        # turns the 0.20.4 "100% data loss on push failure" state
-        # into "push succeeds via transplant" for every failure
-        # pattern we've observed in production.
-        if [ "$_push_ok" != true ]; then
-            hlog "rebase path exhausted, trying scratch worktree fallback"
-            if _scratch_worktree_push; then
-                _push_ok=true
-            fi
-        fi
-
-        if [ "$_push_ok" = true ]; then
-            git fetch --no-recurse-submodules origin 2>&1 | hlog_pipe
-            AFTER=$(git rev-parse origin/agent-work)
-        else
-            hlog_err "push failed after 3 retries and scratch fallback"
-        fi
-    fi
+    _session_end_push || true
 
     if [ "$BEFORE" = "$AFTER" ]; then
         IDLE_COUNT=$((IDLE_COUNT + 1))

--- a/tests/runtime_signal_trap.sh
+++ b/tests/runtime_signal_trap.sh
@@ -1,0 +1,283 @@
+#!/bin/bash
+# shellcheck disable=SC2034
+set -uo pipefail
+
+# tests/runtime_signal_trap.sh
+#
+# Drive the harness's emergency-push paths under real Docker.
+# The structural assertions in tests/test_session_end_push.sh §6
+# and §7 pin the shape of `_session_end_push`, `_run_agent_session`,
+# `_on_signal`, and the TERM/INT trap installation, but cannot
+# prove the trap actually fires under a real container's signal
+# delivery semantics.  This test runs the harness in a real
+# container, drives each abnormal-exit path that previously lost
+# commits, and asserts the commit lands on origin/agent-work.
+#
+# Scenarios:
+#   3. Mid-session SIGTERM  -> exit 143, commit lands.
+#   4. Mid-session SIGINT   -> exit 130, commit lands.
+#   5. Fatal-error session  -> exit 1,   commit lands.
+#   6. cmd_stop banner reads the active SWARM_STOP_TIMEOUT.
+#
+# Requires Docker.  No API key needed -- a synthetic
+# test-committer driver mounts in via `-v` and bypasses every
+# real agent CLI.  Wall-clock: ~30 s after the image is cached.
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$TESTS_DIR/.." && pwd)"
+LAUNCH_SH="${REPO_ROOT}/launch.sh"
+
+# Docker-gated: skip cleanly when the host has no daemon (CI lanes
+# that only run --unit, dev laptops without Docker, etc.).
+if ! command -v docker >/dev/null 2>&1; then
+    echo "SKIP: docker not found"
+    exit 0
+fi
+if ! docker info >/dev/null 2>&1; then
+    echo "SKIP: docker daemon not running"
+    exit 0
+fi
+
+IMAGE_TAG="claude-swarm-runtime-test"
+WORKDIR=$(mktemp -d /tmp/claude-swarm-runtime-XXXXXX)
+NAMES=(
+    claude-swarm-runtime-test-1
+    claude-swarm-runtime-test-2
+    claude-swarm-runtime-test-3
+)
+
+cleanup() {
+    docker rm -f "${NAMES[@]}" 2>/dev/null >/dev/null || true
+    rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+PASS=0
+FAIL=0
+
+check() {
+    local label="$1" actual="$2" expected="$3"
+    if [ "$actual" = "$expected" ]; then
+        echo "    PASS: ${label}  (${actual})"
+        PASS=$((PASS + 1))
+    else
+        echo "    FAIL: ${label}  expected=${expected} got=${actual}"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+check_contains() {
+    local label="$1" haystack="$2" needle="$3"
+    if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+        echo "    PASS: ${label}"
+        PASS=$((PASS + 1))
+    else
+        echo "    FAIL: ${label}  missing '${needle}'"
+        printf '%s\n' "$haystack" | tail -8 | sed 's/^/          /'
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Build the test image (cached after first run).  SWARM_AGENTS=fake
+# skips the claude-code / codex / gemini CLI install layers since
+# the synthetic driver below replaces every real agent.
+echo "--- Building ${IMAGE_TAG} (fake driver only) ---"
+docker build --quiet --tag "$IMAGE_TAG" \
+    --build-arg SWARM_AGENTS=fake "$REPO_ROOT" >/dev/null
+
+# Seed a bare repo on the host that each container will mount as
+# /upstream.  The container's harness clones from /upstream into
+# /workspace, runs a session, and pushes back.
+git init -q --bare --initial-branch=agent-work "$WORKDIR/upstream.git"
+git clone -q "$WORKDIR/upstream.git" "$WORKDIR/seed"
+(
+    cd "$WORKDIR/seed" || exit 1
+    git config user.email t@t
+    git config user.name t
+    mkdir -p prompts
+    echo "test prompt for runtime check" > prompts/test.md
+    git add prompts/test.md
+    git commit -qm seed
+    git push -q origin agent-work
+)
+rm -rf "$WORKDIR/seed"
+
+# Synthetic driver mounted at /drivers/test-committer.sh.  agent_run
+# commits a file in /workspace, then either sleeps so we can
+# interrupt it (items 3, 4) or returns non-zero so the harness's
+# FATAL_MSG path triggers (item 5).  TC_TAG marks each scenario's
+# commit so we can grep for it on origin/agent-work afterwards.
+cat > "$WORKDIR/test-committer.sh" <<'DRIVER'
+#!/bin/bash
+# shellcheck disable=SC2034
+agent_default_model() { echo "test-committer"; }
+agent_name()    { echo "Test Committer"; }
+agent_cmd()     { echo "test-committer"; }
+agent_version() { echo "0.0.0-test"; }
+agent_run() {
+    local model="$1" prompt_text="$2" logfile="$3"
+    cd /workspace || return 1
+    local tag="${TC_TAG:-tc-$$-$RANDOM}"
+    echo "$(date -u +%s) ${tag}" >> committed-by-fake.txt
+    git -c commit.gpgsign=false add committed-by-fake.txt
+    git -c commit.gpgsign=false -c core.hooksPath=/dev/null \
+        commit -qm "test commit [${tag}]" >/dev/null 2>&1
+    {
+        printf '{"type":"system","subtype":"init","session_id":"tc","model":"%s"}\n' "$model"
+        printf '{"type":"result","subtype":"success","session_id":"tc","total_cost_usd":0.0001,"is_error":false,"duration_ms":100,"duration_api_ms":80,"num_turns":1,"usage":{"input_tokens":10,"output_tokens":5,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}\n'
+    } | tee "$logfile" >/dev/null
+    if [ "${TC_FATAL:-0}" = "1" ]; then
+        return 42
+    fi
+    sleep 600
+}
+agent_settings() { :; }
+agent_detect_fatal() {
+    local logfile="$1" exit_code="$2"
+    if [ "${TC_FATAL:-0}" = "1" ] && [ "$exit_code" -ne 0 ]; then
+        echo "test-committer: simulated non-retriable fatal"
+    fi
+}
+agent_is_retriable() { :; }
+agent_extract_stats() {
+    printf '0.0001\t10\t5\t0\t0\t100\t80\t1\n'
+}
+agent_activity_jq() { echo 'fromjson? // empty | empty'; }
+agent_docker_env() { :; }
+agent_docker_auth() { printf -- '-e\nSWARM_AUTH_MODE=\n'; }
+agent_install_cmd() { :; }
+DRIVER
+chmod +x "$WORKDIR/test-committer.sh"
+
+start_container() {
+    local name="$1"
+    shift
+    docker run -d --name "$name" \
+        -v "$WORKDIR/upstream.git:/upstream:rw" \
+        -v "$WORKDIR/test-committer.sh:/drivers/test-committer.sh:ro" \
+        -e SWARM_DRIVER=test-committer \
+        -e SWARM_MODEL=test-committer \
+        -e SWARM_PROMPT=prompts/test.md \
+        -e AGENT_ID=1 \
+        -e GIT_USER_NAME=tc \
+        -e GIT_USER_EMAIL=tc@tc \
+        -e INJECT_GIT_RULES=false \
+        "$@" \
+        "$IMAGE_TAG" >/dev/null
+}
+
+wait_for_session() {
+    local name="$1" timeout="${2:-30}"
+    local i
+    for i in $(seq 1 "$timeout"); do
+        if docker logs "$name" 2>&1 | grep -q "session start at="; then
+            return 0
+        fi
+        sleep 1
+    done
+    echo "    timed out waiting for 'session start' in ${name}"
+    docker logs "$name" 2>&1 | tail -15 | sed 's/^/      /'
+    return 1
+}
+
+await_exit() {
+    local name="$1" timeout="${2:-90}"
+    local i status
+    for i in $(seq 1 "$timeout"); do
+        status=$(docker inspect --format '{{.State.Status}}' \
+            "$name" 2>/dev/null || true)
+        if [ "$status" = "exited" ]; then
+            docker inspect --format '{{.State.ExitCode}}' "$name"
+            return 0
+        fi
+        sleep 1
+    done
+    echo "    timed out waiting for ${name} to exit"
+    return 1
+}
+
+count_landed() {
+    local tag="$1"
+    git -C "$WORKDIR/upstream.git" log --oneline agent-work \
+        2>/dev/null | grep -cF -- "[$tag]" || true
+}
+
+echo
+echo "=== Item 3: SIGTERM mid-session ==="
+start_container "${NAMES[0]}" -e TC_TAG=sigterm-tag
+wait_for_session "${NAMES[0]}" || exit 1
+sleep 2
+echo "  sending docker stop -t 60..."
+docker stop -t 60 "${NAMES[0]}" >/dev/null
+EXIT_3=$(await_exit "${NAMES[0]}")
+LOGS_3=$(docker logs "${NAMES[0]}" 2>&1)
+check          "exit code"                      "$EXIT_3" "143"
+check_contains "log: received SIGTERM"          "$LOGS_3" "received SIGTERM"
+check_contains "log: attempting emergency push" "$LOGS_3" "attempting emergency push"
+check_contains "log: emergency shutdown complete" \
+    "$LOGS_3" "emergency shutdown complete"
+check          "commit landed on agent-work"    "$(count_landed sigterm-tag)" "1"
+echo
+
+echo "=== Item 4: SIGINT mid-session ==="
+start_container "${NAMES[1]}" -e TC_TAG=sigint-tag
+wait_for_session "${NAMES[1]}" || exit 1
+sleep 2
+echo "  sending docker kill --signal=SIGINT..."
+docker kill --signal=SIGINT "${NAMES[1]}" >/dev/null
+EXIT_4=$(await_exit "${NAMES[1]}")
+LOGS_4=$(docker logs "${NAMES[1]}" 2>&1)
+check          "exit code"                      "$EXIT_4" "130"
+check_contains "log: received SIGINT"           "$LOGS_4" "received SIGINT"
+check_contains "log: attempting emergency push" "$LOGS_4" "attempting emergency push"
+check_contains "log: emergency shutdown complete" \
+    "$LOGS_4" "emergency shutdown complete"
+check          "commit landed on agent-work"    "$(count_landed sigint-tag)" "1"
+echo
+
+echo "=== Item 5: Fatal-error mid-session ==="
+start_container "${NAMES[2]}" -e TC_TAG=fatal-tag -e TC_FATAL=1
+wait_for_session "${NAMES[2]}" || exit 1
+EXIT_5=$(await_exit "${NAMES[2]}")
+LOGS_5=$(docker logs "${NAMES[2]}" 2>&1)
+check          "exit code"                      "$EXIT_5" "1"
+check_contains "log: fatal: test-committer"     "$LOGS_5" "fatal: test-committer"
+check_contains "log: exiting due to unrecoverable error" \
+    "$LOGS_5" "exiting due to unrecoverable error"
+check          "commit landed on agent-work"    "$(count_landed fatal-tag)" "1"
+echo
+
+echo "=== Item 6: SWARM_STOP_TIMEOUT banner ==="
+FAKE_DIR="$WORKDIR/fake-bin"
+mkdir -p "$FAKE_DIR"
+cat > "$FAKE_DIR/docker" <<'FD'
+#!/bin/bash
+exit 0
+FD
+chmod +x "$FAKE_DIR/docker"
+
+CMD_STOP_BODY=$(awk '/^cmd_stop\(\) \{/,/^\}$/' "$LAUNCH_SH")
+
+BANNER_DEFAULT=$(
+    eval "$CMD_STOP_BODY"
+    NUM_AGENTS=2 IMAGE_NAME=fake PROJECT=fake \
+        PATH="$FAKE_DIR:$PATH" cmd_stop 2>&1 | head -1
+)
+check "default banner" \
+    "$BANNER_DEFAULT" "--- Stopping agents (grace 60s) ---"
+
+BANNER_120=$(
+    eval "$CMD_STOP_BODY"
+    NUM_AGENTS=2 IMAGE_NAME=fake PROJECT=fake \
+        PATH="$FAKE_DIR:$PATH" SWARM_STOP_TIMEOUT=120 cmd_stop 2>&1 \
+        | head -1
+)
+check "SWARM_STOP_TIMEOUT=120 banner" \
+    "$BANNER_120" "--- Stopping agents (grace 120s) ---"
+echo
+
+echo "==============================="
+echo "  ${PASS} passed, ${FAIL} failed"
+echo "==============================="
+
+[ "$FAIL" -eq 0 ]

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -8,7 +8,8 @@ set -euo pipefail
 #
 # Options:
 #   --unit          Run unit tests only (no Docker or API key needed).
-#   --all           Run unit tests then full integration matrix.
+#   --runtime       Runtime emergency-push test (Docker only, no API key).
+#   --all           Unit + runtime, then full integration matrix.
 #   --oauth         Integration test using OAuth token (needs Docker +
 #                   CLAUDE_CODE_OAUTH_TOKEN).
 #   --config FILE   Use a swarmfile for mixed-model testing.
@@ -40,7 +41,9 @@ rm_docker_dir() {
 # ---- --all: full test suite runner ----
 
 run_all_tests() {
-    local total_start unit_fail=0 int_pass=0 int_fail=0
+    local total_start unit_fail=0 runtime_fail=0
+    local int_pass=0 int_fail=0
+    local runtime_skip=0
     total_start=$(date +%s)
 
     echo "============================================================"
@@ -50,6 +53,34 @@ run_all_tests() {
 
     # Phase 1: unit tests.
     cmd_unit || unit_fail=1
+    echo ""
+
+    # Phase 1.5: Docker-only runtime tests (no API key required).
+    # Drives the harness's SIGTERM / SIGINT / fatal-exit emergency
+    # push under a real container.  Pure structural assertions in
+    # test_session_end_push.sh §6 / §7 cannot prove the signal trap
+    # actually fires; this phase does.  Skips cleanly when Docker
+    # is unavailable so --all stays useful on hosts without it.
+    echo "=== Phase 1.5: Runtime emergency-push test ==="
+    echo ""
+    if ! command -v docker >/dev/null 2>&1; then
+        echo "  SKIP  (docker not found)"
+        runtime_skip=1
+    elif ! docker info >/dev/null 2>&1; then
+        echo "  SKIP  (docker daemon not running)"
+        runtime_skip=1
+    else
+        local rt_start rt_elapsed rt_rc=0
+        rt_start=$(date +%s)
+        "$TESTS_DIR/runtime_signal_trap.sh" || rt_rc=$?
+        rt_elapsed=$(( $(date +%s) - rt_start ))
+        if [ "$rt_rc" -eq 0 ]; then
+            printf "  PASS  runtime_signal_trap.sh (%ds)\n" "$rt_elapsed"
+        else
+            printf "  FAIL  runtime_signal_trap.sh (%ds)\n" "$rt_elapsed"
+            runtime_fail=1
+        fi
+    fi
     echo ""
 
     # Phase 2: integration tests (require ANTHROPIC_API_KEY).
@@ -153,6 +184,13 @@ run_all_tests() {
     else
         echo "  Unit:        FAIL"
     fi
+    if [ "$runtime_skip" -eq 1 ]; then
+        echo "  Runtime:     SKIP (docker unavailable)"
+    elif [ "$runtime_fail" -eq 0 ]; then
+        echo "  Runtime:     PASS"
+    else
+        echo "  Runtime:     FAIL"
+    fi
     if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
         printf "  Integration: %d/%d passed\n" \
             "$int_pass" $((int_pass + int_fail))
@@ -168,7 +206,8 @@ run_all_tests() {
     printf "  Total time:  %dm %02ds\n" "$total_m" "$total_s"
     echo "============================================================"
 
-    [ "$unit_fail" -eq 0 ] && [ "$int_fail" -eq 0 ] && [ "$oauth_fail" -eq 0 ]
+    [ "$unit_fail" -eq 0 ] && [ "$runtime_fail" -eq 0 ] \
+        && [ "$int_fail" -eq 0 ] && [ "$oauth_fail" -eq 0 ]
 }
 
 run_integration_case() {
@@ -341,7 +380,10 @@ Run claude-swarm tests.
 Options:
   (no args)         Single integration smoke test (needs Docker + API key).
   --unit            Unit tests only (no Docker or API key needed).
-  --all             Unit tests, then full integration matrix.
+  --runtime         Runtime emergency-push test (needs Docker, no API key).
+                    Drives SIGTERM / SIGINT / fatal-exit paths under a
+                    real container with a synthetic test-committer driver.
+  --all             Unit + runtime, then full integration matrix.
   --oauth           Integration test using CLAUDE_CODE_OAUTH_TOKEN
                     (needs Docker + OAuth token).
   --config FILE     Use a swarmfile for mixed-model testing.
@@ -361,6 +403,7 @@ NO_INJECT=false
 RUN_ALL=false
 RUN_UNIT=false
 RUN_OAUTH=false
+RUN_RUNTIME=false
 _AUTO_CONFIG=""
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -375,6 +418,7 @@ while [ $# -gt 0 ]; do
         --all) RUN_ALL=true; shift ;;
         --unit) RUN_UNIT=true; shift ;;
         --oauth) RUN_OAUTH=true; shift ;;
+        --runtime) RUN_RUNTIME=true; shift ;;
         -h|--help) cmd_help; exit 0 ;;
         *) echo "Unknown option: $1 (try --help)" >&2; exit 1 ;;
     esac
@@ -387,6 +431,11 @@ fi
 
 if $RUN_OAUTH; then
     cmd_oauth
+    exit $?
+fi
+
+if $RUN_RUNTIME; then
+    "$TESTS_DIR/runtime_signal_trap.sh"
     exit $?
 fi
 

--- a/tests/test_launch.sh
+++ b/tests/test_launch.sh
@@ -1591,6 +1591,71 @@ assert_eq "build_image forwards CODEX_CLI_VERSION build-arg" "1" \
 
 # ============================================================
 echo ""
+echo "=== 40. cmd_stop gives the harness time to push ==="
+
+# `docker stop` defaults to SIGTERM + 10s grace + SIGKILL.  The
+# harness's SIGTERM trap pushes any in-flight local commits via
+# `_session_end_push`, which on a contended bare repo (45+
+# agents racing the same push lock) can easily take more than
+# 10s to land.  Without `-t`, that emergency push gets cut
+# mid-rebase and the commits die with the container.  Pin the
+# flag's presence, the default, and the env-var override.
+LAUNCH_FILE="$TESTS_DIR/../launch.sh"
+CMD_STOP_BODY=$(awk '/^cmd_stop\(\) \{/,/^\}$/' "$LAUNCH_FILE")
+assert_eq "cmd_stop passes -t to docker stop" "1" \
+    "$(printf '%s\n' "$CMD_STOP_BODY" \
+        | grep -cF 'docker stop -t "$stop_timeout"')"
+assert_eq "cmd_stop defaults grace to 60s" "1" \
+    "$(printf '%s\n' "$CMD_STOP_BODY" \
+        | grep -cF 'stop_timeout="${SWARM_STOP_TIMEOUT:-60}"')"
+
+# Fake docker so we can observe the exact flags cmd_stop uses.
+FAKE_DOCKER_DIR=$(mktemp -d)
+trap_dir="$TMPDIR/cmd_stop_invocations"
+mkdir -p "$trap_dir"
+cat > "$FAKE_DOCKER_DIR/docker" <<FAKE
+#!/bin/bash
+echo "\$@" >> "$trap_dir/calls"
+exit 0
+FAKE
+chmod +x "$FAKE_DOCKER_DIR/docker"
+
+# Pull cmd_stop out of launch.sh into a sourceable file so we
+# do not have to run the launch.sh argv dispatcher.
+cmd_stop_src=$(awk '/^cmd_stop\(\) \{/,/^\}$/' "$LAUNCH_FILE")
+
+# Default grace: 60.
+: > "$trap_dir/calls"
+(
+    eval "$cmd_stop_src"
+    NUM_AGENTS=3
+    IMAGE_NAME="claude-swarm-fake"
+    PROJECT="fake"
+    PATH="$FAKE_DOCKER_DIR:$PATH" cmd_stop >/dev/null 2>&1 || true
+)
+default_calls=$(wc -l < "$trap_dir/calls" | tr -d ' ')
+assert_eq "default grace: 3 docker stop invocations" \
+    "3" "$default_calls"
+default_flag=$(head -1 "$trap_dir/calls")
+assert_eq "default grace: -t 60 in flags" "1" \
+    "$(printf '%s\n' "$default_flag" | grep -cF 'stop -t 60')"
+
+# Env override: SWARM_STOP_TIMEOUT=120.
+: > "$trap_dir/calls"
+(
+    eval "$cmd_stop_src"
+    NUM_AGENTS=2
+    IMAGE_NAME="claude-swarm-fake"
+    PROJECT="fake"
+    SWARM_STOP_TIMEOUT=120 PATH="$FAKE_DOCKER_DIR:$PATH" \
+        cmd_stop >/dev/null 2>&1 || true
+)
+override_flag=$(head -1 "$trap_dir/calls")
+assert_eq "SWARM_STOP_TIMEOUT=120 propagates to docker stop -t 120" "1" \
+    "$(printf '%s\n' "$override_flag" | grep -cF 'stop -t 120')"
+
+# ============================================================
+echo ""
 echo "==============================="
 echo "  ${PASS} passed, ${FAIL} failed"
 echo "==============================="

--- a/tests/test_session_end_push.sh
+++ b/tests/test_session_end_push.sh
@@ -398,6 +398,78 @@ assert_contains "3-fail scenario: park_ok=false" \
 
 # ============================================================
 echo ""
+echo "=== 6. Fatal-exit paths ship local commits ==="
+
+# The session-end push pipeline has been hoisted out of the loop
+# body into a function named `_session_end_push` so it can be
+# called from both the happy path AND the FATAL_MSG handling
+# block, which used to `exit 1` while local commits sat unshipped
+# in /workspace/.git.  Pin the function's existence, its sole
+# inline use, and a call before every fatal exit.
+assert_eq "_session_end_push function defined exactly once" \
+    "1" \
+    "$(grep -cE '^_session_end_push\(\) \{$' "$HARNESS_FILE")"
+
+# The function must update the global AFTER on push success so
+# the per-iteration idle counter sees the new origin/agent-work
+# tip without an extra fetch from the caller.  Without this the
+# happy path mistakenly counts a successful push as "idle".
+SEP_BODY=$(awk '/^_session_end_push\(\) \{/,/^\}$/' \
+    "$HARNESS_FILE")
+assert_contains "_session_end_push updates AFTER on success" \
+    'AFTER=$(git rev-parse origin/agent-work)' "$SEP_BODY"
+
+# Pin three fatal `exit 1` sites inside the FATAL_MSG block,
+# each preceded by a `_session_end_push || true` so commits the
+# agent landed locally before the fatal error get pushed instead
+# of dying with the container.
+FATAL_BLOCK=$(awk '
+    /^    if \[ -n "\$FATAL_MSG" \]; then$/ { inside = 1 }
+    inside                                   { print }
+    inside && /^    fi$/                     { exit }
+' "$HARNESS_FILE")
+assert_eq "FATAL_MSG block has 3 exit-1 sites" \
+    "3" \
+    "$(printf '%s' "$FATAL_BLOCK" | grep -cE '^[[:space:]]+exit 1$')"
+assert_eq "FATAL_MSG block has 3 _session_end_push calls" \
+    "3" \
+    "$(printf '%s' "$FATAL_BLOCK" \
+        | grep -cE '_session_end_push \|\| true')"
+
+# Each exit 1 inside the FATAL_MSG block must be immediately
+# preceded by a `_session_end_push || true` line (allowing only
+# blank/comment lines in between).  Awk walks the block, tags
+# any line that contains _session_end_push, then asserts that
+# every exit-1 has such a tag set in the previous non-blank,
+# non-comment line.
+PREORDER_OK=$(printf '%s' "$FATAL_BLOCK" | awk '
+    /_session_end_push \|\| true/ { staged = 1; next }
+    /^[[:space:]]*#/              { next }
+    /^[[:space:]]*$/              { next }
+    /^[[:space:]]+exit 1$/        {
+        if (!staged) {
+            bad++
+        }
+        staged = 0
+        next
+    }
+    {
+        staged = 0
+    }
+    END { print (bad ? "no" : "yes") }
+')
+assert_eq "every fatal exit 1 is preceded by _session_end_push" \
+    "yes" "$PREORDER_OK"
+
+# The inline session-end use (happy path between sessions) is
+# the only other call to the function -- 1 inline use + 3 fatal
+# uses == 4 callers total, plus the definition == 5 occurrences.
+assert_eq "_session_end_push referenced exactly 5 times" \
+    "5" \
+    "$(grep -cE '_session_end_push' "$HARNESS_FILE")"
+
+# ============================================================
+echo ""
 echo "==============================="
 echo "  ${PASS} passed, ${FAIL} failed"
 echo "==============================="

--- a/tests/test_session_end_push.sh
+++ b/tests/test_session_end_push.sh
@@ -461,12 +461,73 @@ PREORDER_OK=$(printf '%s' "$FATAL_BLOCK" | awk '
 assert_eq "every fatal exit 1 is preceded by _session_end_push" \
     "yes" "$PREORDER_OK"
 
-# The inline session-end use (happy path between sessions) is
-# the only other call to the function -- 1 inline use + 3 fatal
-# uses == 4 callers total, plus the definition == 5 occurrences.
-assert_eq "_session_end_push referenced exactly 5 times" \
-    "5" \
+# Call-site accounting:
+#   1 definition + 1 inline (happy path) + 3 fatal-exit blocks
+#   + 1 emergency-shutdown trap == 6 occurrences total.
+# Pinning the total is a tripwire against an accidental extra
+# reference; each individual site is also asserted above and
+# (for the trap) in §7 below.
+assert_eq "_session_end_push referenced exactly 6 times" \
+    "6" \
     "$(grep -cE '_session_end_push' "$HARNESS_FILE")"
+
+# ============================================================
+echo ""
+echo "=== 7. Signal trap ships local commits before exit ==="
+
+# Without a trap, `docker stop` (SIGTERM with a 10s default
+# grace then SIGKILL) abandons unpushed commits sitting in
+# /workspace/.git -- the harness is parked in a foreground
+# wait and bash defers traps until the foreground child
+# returns.  Two pieces must be in place: (1) the agent
+# pipeline runs in a backgrounded subshell so a `wait`
+# builtin is what's interruptible, and (2) the trap handler
+# kills the agent and runs the session-end push before exit.
+
+# (1) agent_run pipeline runs in background and is awaited.
+assert_eq "agent_run pipeline runs in a backgrounded subshell" \
+    "1" \
+    "$(grep -cE '\( agent_run "\$model" "\$prompt" "\$logfile" "\$append" \\$' \
+        "$HARNESS_FILE")"
+assert_eq "_run_agent_session captures \$! and waits on it" \
+    "1" \
+    "$(grep -cE 'wait "\$_SESSION_PID"' "$HARNESS_FILE")"
+assert_eq "_SESSION_PID is reset to empty after wait" \
+    "1" \
+    "$(grep -cE '^[[:space:]]+_SESSION_PID=""$' "$HARNESS_FILE")"
+
+# Both per-loop agent invocations (initial + retry) use the
+# wrapper instead of the bare pipeline.  A regression here
+# would silently re-deafen the harness to SIGTERM for one of
+# the two session entry points.  We match the bug-specific
+# foreground tail (`/activity-filter.sh || AGENT_RUN_EXIT=$?`)
+# rather than just the pipe -- the wrapper's own backgrounded
+# pipeline lives inside a `( ... ) &` subshell and is not
+# foreground.
+assert_eq "no foreground agent_run | activity-filter pipelines" \
+    "0" \
+    "$(grep -cE '/activity-filter\.sh \|\| AGENT_RUN_EXIT=\$\?' \
+        "$HARNESS_FILE")"
+assert_eq "two _run_agent_session call sites" \
+    "2" \
+    "$(grep -cE '^[[:space:]]+_run_agent_session "\$SWARM_MODEL"' \
+        "$HARNESS_FILE")"
+
+# (2) Trap is installed for TERM and INT and runs _on_signal,
+# which kills the running pipeline, pushes, and exits 143/130.
+assert_eq "trap _on_signal TERM installed" "1" \
+    "$(grep -cE "^trap '_on_signal TERM' TERM\$" "$HARNESS_FILE")"
+assert_eq "trap _on_signal INT installed" "1" \
+    "$(grep -cE "^trap '_on_signal INT' INT\$" "$HARNESS_FILE")"
+ON_SIGNAL_BODY=$(awk '/^_on_signal\(\) \{$/,/^\}$/' "$HARNESS_FILE")
+assert_contains "_on_signal kills the running agent session" \
+    'kill -TERM "$_SESSION_PID"' "$ON_SIGNAL_BODY"
+assert_contains "_on_signal calls _session_end_push" \
+    '_session_end_push' "$ON_SIGNAL_BODY"
+assert_contains "_on_signal exits with TERM code 143" \
+    'exit_code=143' "$ON_SIGNAL_BODY"
+assert_contains "_on_signal exits with INT code 130" \
+    'exit_code=130' "$ON_SIGNAL_BODY"
 
 # ============================================================
 echo ""


### PR DESCRIPTION
## Summary

- Hoist the session-end push into `_session_end_push` and call it before every fatal `exit 1`.
- Wrap the agent pipeline in `( ... ) &; wait` and install a SIGTERM/SIGINT trap that runs the same push before exit.
- Pass `-t "${SWARM_STOP_TIMEOUT:-60}"` to `docker stop` so the emergency push has time to land before SIGKILL.
- +22 structural / behavioural tests; existing 1,227 unchanged.

## Changes

- `lib/harness.sh`: extract `_session_end_push`; add `_run_agent_session` + `_on_signal`; install TERM/INT traps; call push before each fatal `exit 1`.
- `launch.sh`: `cmd_stop` passes `-t "${SWARM_STOP_TIMEOUT:-60}"` and echoes the active grace.
- `tests/test_session_end_push.sh`: new §6 (fatal-exit ordering) and §7 (wait + trap + handler).
- `tests/test_launch.sh`: new §40 (`-t` flag, default, env-var override).
- `CHANGELOG.md`: Unreleased entry summarising the three code commits.
- `USAGE.md`: `SWARM_STOP_TIMEOUT` row + new "Stopping the swarm" subsection.

## Test plan

- [x] `./tests/test.sh --unit` → 1,249 pass (was 1,227 on master).
- [x] `shellcheck -s bash lib/harness.sh launch.sh tests/test_session_end_push.sh tests/test_launch.sh` → no new notices vs master.
- [x] Mid-session `docker stop -t 60 <container>` → exits 143, last log line `emergency shutdown complete`, commits land on `origin/agent-work`.
- [x] Mid-session `docker kill --signal=SIGINT <container>` → exits 130, same log line, commits land.
- [x] Agent with non-retriable error commits, harness exits 1, commit lands on `origin/agent-work`.
- [x] `SWARM_STOP_TIMEOUT=120 ./launch.sh stop` → banner reads `Stopping agents (grace 120s)`.

## Acknowledgements

 Thanks to @fredrik0x for the testing that surfaced this — a 45-agent swarm where, after a routine `docker stop`, 44 of 45 containers held unpushed commits (1,639 total). The recovery's `SUMMARY.md` mapped exit code to unpushed count per agent and split the failures into three clusters (`Exited 1`, `137`, `128`), which is what pointed at three separate fixes instead of one.