### PR TITLE
Fix post-process dashboard and launch naming issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@
   the post-process run only after an explicit confirmation prompt,
   so an accidental keypress does not stop agents and launch triage.
 
+- **Docs: clarify that `launch.sh wait` does not start agents.**
+  Command help, quick-start docs, and post-processing docs now show
+  the intended sequence: run `start` first, then `wait`.
+  `harvest.sh` is documented as a merge-only helper that does not
+  trigger `post_process`; `post-process` is the direct command for
+  manual post-processing followed by harvest.
+
 ## 0.20.15 — 2026-05-16
 
 - **Test: runtime emergency-push verification under `--all`.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
   context.  Dashboard, harvest, progress, cost, and test helpers
   use the same sanitizer so they agree on the internal names.
 
+- **Fix: configured post-processing is visible before it starts.**
+  The dashboard now renders a synthetic `PP` row from
+  `post_process` config when no post-process container exists yet,
+  marked `configured`.  Once the container exists, the row still
+  uses the live Docker state, stats, and environment as before.
+
 ## 0.20.15 — 2026-05-16
 
 - **Test: runtime emergency-push verification under `--all`.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+- **Fix: Docker project names are sanitized for uppercase repo
+  basenames.**  `launch.sh` now derives a lowercase Docker-safe
+  project id for image names, container names, and `/tmp` paths,
+  while preserving the raw repository basename in user-facing run
+  context.  Dashboard, harvest, progress, cost, and test helpers
+  use the same sanitizer so they agree on the internal names.
+
 ## 0.20.15 — 2026-05-16
 
 - **Test: runtime emergency-push verification under `--all`.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@
   marked `configured`.  Once the container exists, the row still
   uses the live Docker state, stats, and environment as before.
 
+- **Fix: dashboard post-process logs get a dedicated shortcut.**
+  Lowercase `p` now follows the existing `PP` container logs and
+  never starts post-processing.  Uppercase `P` starts or replaces
+  the post-process run only after an explicit confirmation prompt,
+  so an accidental keypress does not stop agents and launch triage.
+
 ## 0.20.15 — 2026-05-16
 
 - **Test: runtime emergency-push verification under `--all`.**

--- a/README.md
+++ b/README.md
@@ -61,8 +61,11 @@ see the changes on the next fetch.
 ## Quick start
 
 ```bash
-# Create a swarmfile and launch.
+# Create a swarmfile and launch numbered agents.
 SWARM_CONFIG=swarm.json ./launch.sh start --dashboard
+
+# Later, after agents are running or have exited:
+SWARM_CONFIG=swarm.json ./launch.sh wait
 
 # Or place swarm.json in your repo root and launch.
 ./launch.sh start --dashboard

--- a/USAGE.md
+++ b/USAGE.md
@@ -3,8 +3,11 @@
 ## Quick start
 
 ```bash
-# Create a swarmfile and launch.
+# Create a swarmfile and launch numbered agents.
 SWARM_CONFIG=swarm.json ./launch.sh start --dashboard
+
+# Later, after agents are running or have exited:
+SWARM_CONFIG=swarm.json ./launch.sh wait
 ```
 
 All configuration lives in the swarmfile (JSON).  Place a
@@ -13,12 +16,16 @@ All configuration lives in the swarmfile (JSON).  Place a
 ## Commands
 
 ```bash
-./launch.sh start [--dashboard]   # Launch agents.
+./launch.sh start [--dashboard]   # Launch numbered agents.
 ./launch.sh stop                  # Stop all agents.
 ./launch.sh status                # Show containers.
 ./launch.sh logs N                # Tail agent N logs.
-./launch.sh wait                  # Block, harvest, post-process.
-./launch.sh post-process          # Run post-process agent.
+./launch.sh wait                  # Wait for already-started
+                                  # numbered agents, then
+                                  # post-process and harvest.
+                                  # Does not start agents.
+./launch.sh post-process          # Run only post-process, then
+                                  # harvest.
 ```
 
 ## Environment variables
@@ -259,7 +266,8 @@ header shows a compact model summary on a single line.
 | `1`-`9` | Logs for agent N. |
 | `h` | Harvest results. |
 | `s` | Stop numbered agents (not post-process). |
-| `p` | Post-process. |
+| `p` | Logs for the post-process container, if it exists. |
+| `P` | Start post-process after confirmation. |
 
 ## Activity streaming
 
@@ -370,11 +378,19 @@ Add to `swarm.json`:
 }
 ```
 
-Trigger via `[p]` in the dashboard, `./launch.sh post-process`,
-or automatically via `./launch.sh wait`.
+Trigger via `[P]` in the dashboard, `./launch.sh post-process`,
+or automatically via `./launch.sh wait` after numbered agents have
+already been started. `./launch.sh wait` does not launch numbered
+agents.
 
 The post-process agent clones the same bare repo, sees all
 commits on `agent-work`, runs its prompt, and pushes.
+
+`harvest.sh` only merges agent work into the current local branch.
+It does not run `post_process`. If you harvested manually and still
+need post-processing, run `./launch.sh post-process`; use that
+command directly when you intentionally want to run only the
+post-process agent and then harvest.
 
 `post_process` also accepts `base_url`, `api_key`,
 `auth_token`, `auth`, `tag`, `driver`, and `max_idle` -- same

--- a/costs.sh
+++ b/costs.sh
@@ -30,9 +30,11 @@ fi
 
 source "$SWARM_DIR/lib/check-deps.sh"
 check_deps git jq docker bc
+# shellcheck source=lib/project.sh
+source "$SWARM_DIR/lib/project.sh"
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-PROJECT="$(basename "$REPO_ROOT")"
+PROJECT="$(swarm_project_id "$(basename "$REPO_ROOT")")"
 IMAGE_NAME="${PROJECT}-agent"
 JSON_MODE=false
 

--- a/dashboard.sh
+++ b/dashboard.sh
@@ -29,7 +29,8 @@ Keybindings:
   1-9         Tail logs for agent N.
   h           Harvest agent results into current branch.
   s           Stop numbered agents (not post-process).
-  p           Run post-processing agent.
+  p           Tail post-process logs when the PP container exists.
+  P           Start the post-processing agent after confirmation.
 
 Environment:
   SWARM_TITLE    Dashboard title override.
@@ -299,6 +300,21 @@ read_retry_state() {
     fi
 }
 
+post_process_configured() {
+    local _pp_prompt
+    [ -n "$CONFIG_FILE" ] && [ -f "$CONFIG_FILE" ] || return 1
+    _pp_prompt=$(jq -r '.post_process.prompt // empty' \
+        "$CONFIG_FILE" 2>/dev/null || true)
+    [ -n "$_pp_prompt" ]
+}
+
+post_process_container_exists() {
+    local _pp_state
+    _pp_state=$(docker inspect -f '{{.State.Status}}' \
+        "${IMAGE_NAME}-post" 2>/dev/null || true)
+    [ -n "$_pp_state" ] && [ "$_pp_state" != "none" ]
+}
+
 emit_row() {
     local id_str="$1" model_str="$2" driver_str="$3" auth_str="$4"
     local status_color="$5" status_str="$6"
@@ -546,31 +562,26 @@ draw() {
             "$(format_tokens "$pp_cache")" \
             "$pp_turns" "$(format_tps "$pp_out" "$pp_api_ms")" \
             "$(format_duration_ms "$pp_dur")" "$pp_tag"
-    elif [ -n "$CONFIG_FILE" ] && [ -f "$CONFIG_FILE" ]; then
-        local pp_prompt
-        pp_prompt=$(jq -r '.post_process.prompt // empty' \
+    elif post_process_configured; then
+        local pp_model pp_effort pp_auth_mode pp_tag pp_driver
+        pp_model=$(jq -r '.post_process.model // "claude-opus-4-6"' \
+            "$CONFIG_FILE" 2>/dev/null || echo "claude-opus-4-6")
+        pp_effort=$(jq -r '.post_process.effort // empty' \
             "$CONFIG_FILE" 2>/dev/null || true)
-        if [ -n "$pp_prompt" ]; then
-            local pp_model pp_effort pp_auth_mode pp_tag pp_driver
-            pp_model=$(jq -r '.post_process.model // "claude-opus-4-6"' \
-                "$CONFIG_FILE" 2>/dev/null || echo "claude-opus-4-6")
-            pp_effort=$(jq -r '.post_process.effort // empty' \
-                "$CONFIG_FILE" 2>/dev/null || true)
-            pp_auth_mode=$(jq -r '.post_process.auth // empty' \
-                "$CONFIG_FILE" 2>/dev/null || true)
-            pp_tag=$(jq -r '.post_process.tag // .tag // empty' \
-                "$CONFIG_FILE" 2>/dev/null || true)
-            pp_driver=$(jq -r '.post_process.driver // .driver // "claude-code"' \
-                "$CONFIG_FILE" 2>/dev/null || echo "claude-code")
+        pp_auth_mode=$(jq -r '.post_process.auth // empty' \
+            "$CONFIG_FILE" 2>/dev/null || true)
+        pp_tag=$(jq -r '.post_process.tag // .tag // empty' \
+            "$CONFIG_FILE" 2>/dev/null || true)
+        pp_driver=$(jq -r '.post_process.driver // .driver // "claude-code"' \
+            "$CONFIG_FILE" 2>/dev/null || echo "claude-code")
 
-            local pp_rule
-            pp_rule=$(printf '%.0s·' $(seq 1 $((TERM_COLS - 4))))
-            printf "  ${DIM}%s${RESET}\n" "$pp_rule"
-            emit_row "PP" "$(format_model "$pp_model" "$pp_effort")" \
-                "$(short_driver "$pp_driver")" "$pp_auth_mode" \
-                "$DIM" "configured" \
-                "" "" "" "" "" "" "$pp_tag"
-        fi
+        local pp_rule
+        pp_rule=$(printf '%.0s·' $(seq 1 $((TERM_COLS - 4))))
+        printf "  ${DIM}%s${RESET}\n" "$pp_rule"
+        emit_row "PP" "$(format_model "$pp_model" "$pp_effort")" \
+            "$(short_driver "$pp_driver")" "$pp_auth_mode" \
+            "$DIM" "configured" \
+            "" "" "" "" "" "" "$pp_tag"
     fi
 
     # Totals row.
@@ -617,8 +628,14 @@ draw() {
     printf "  ${DIM}[h]${RESET} harvest"
     # shellcheck disable=SC2059
     printf "  ${DIM}[s]${RESET} stop all"
-    # shellcheck disable=SC2059
-    printf "  ${DIM}[p]${RESET} post-process"
+    if post_process_container_exists; then
+        # shellcheck disable=SC2059
+        printf "  ${DIM}[p]${RESET} pp logs"
+    fi
+    if post_process_configured; then
+        # shellcheck disable=SC2059
+        printf "  ${DIM}[P]${RESET} start pp"
+    fi
     printf "\n"
 }
 
@@ -661,20 +678,52 @@ while true; do
                 read -rp "Press Enter to return to dashboard..." _
                 enter_alt_screen
                 ;;
-            p|P)
+            p)
                 leave_alt_screen
-                _pp_configured=false
-                if [ -n "$CONFIG_FILE" ] && [ -f "$CONFIG_FILE" ]; then
-                    _pp_prompt=$(jq -r '.post_process.prompt // empty' "$CONFIG_FILE" 2>/dev/null)
-                    [ -n "$_pp_prompt" ] && _pp_configured=true
+                _pp_name="${IMAGE_NAME}-post"
+                if post_process_container_exists; then
+                    echo "--- Logs for ${_pp_name} (Ctrl-C to return) ---"
+                    docker logs -f "$_pp_name" 2>&1 || true
+                    if ! docker inspect -f '{{.State.Running}}' \
+                            "$_pp_name" 2>/dev/null | grep -q true; then
+                        echo ""
+                        read -rp "Press Enter to return to dashboard..." _
+                    fi
+                else
+                    echo "(post-processing is not running -- press P to start)"
+                    echo ""
+                    read -rp "Press Enter to return to dashboard..." _
                 fi
-                if ! $_pp_configured; then
-                    echo "(post-processing not configured -- add post_process to swarm.json)"
+                enter_alt_screen
+                ;;
+            P)
+                leave_alt_screen
+                if ! post_process_configured; then
+                    echo "(post-processing not configured)"
+                    echo "Add post_process to swarm.json."
                     echo ""
                     read -rp "Press Enter to return to dashboard..." _
                     enter_alt_screen
                     continue
                 fi
+                _pp_name="${IMAGE_NAME}-post"
+                if post_process_container_exists; then
+                    _pp_prompt="Replace existing ${_pp_name} with a new run?"
+                    _pp_prompt="${_pp_prompt} [y/N] "
+                else
+                    _pp_prompt="Start post-processing now? [y/N] "
+                fi
+                read -r -p "$_pp_prompt" _pp_confirm || _pp_confirm=""
+                case "$_pp_confirm" in
+                    y|Y|yes|YES) ;;
+                    *)
+                        echo "(post-processing not started)"
+                        echo ""
+                        read -rp "Press Enter to return to dashboard..." _
+                        enter_alt_screen
+                        continue
+                        ;;
+                esac
                 echo "--- Stopping agents ---"
                 for i in $(seq 1 "$NUM_AGENTS"); do
                     docker stop "${IMAGE_NAME}-${i}" 2>/dev/null || true

--- a/dashboard.sh
+++ b/dashboard.sh
@@ -40,9 +40,12 @@ fi
 
 source "$SWARM_DIR/lib/check-deps.sh"
 check_deps git jq docker tput bc
+# shellcheck source=lib/project.sh
+source "$SWARM_DIR/lib/project.sh"
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-PROJECT="$(basename "$REPO_ROOT")"
+PROJECT_RAW="$(basename "$REPO_ROOT")"
+PROJECT="$(swarm_project_id "$PROJECT_RAW")"
 BARE_REPO="/tmp/${PROJECT}-upstream.git"
 IMAGE_NAME="${PROJECT}-agent"
 START_TIME=$(date +%s)
@@ -50,8 +53,8 @@ START_TIME=$(date +%s)
 GIT_BRANCH=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
 GIT_SHORT_HEAD=$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || echo "")
 
-DEFAULT_TITLE="${PROJECT}"
-[ -n "$GIT_SHORT_HEAD" ] && DEFAULT_TITLE="${PROJECT} (@${GIT_SHORT_HEAD})"
+DEFAULT_TITLE="${PROJECT_RAW}"
+[ -n "$GIT_SHORT_HEAD" ] && DEFAULT_TITLE="${PROJECT_RAW} (@${GIT_SHORT_HEAD})"
 
 # Save user's explicit env var so it takes priority over state file.
 USER_TITLE="${SWARM_TITLE:-}"

--- a/dashboard.sh
+++ b/dashboard.sh
@@ -121,8 +121,10 @@ fi
 HAS_MULTI_DRIVERS=false
 DRV_COL_W=6
 if [ -n "$CONFIG_FILE" ]; then
-    _nd=$(jq -r '.driver as $dd | [.agents[] | (.driver // $dd // "claude-code")] | unique | length' \
-        "$CONFIG_FILE" 2>/dev/null || echo 1)
+    _nd=$(jq -r '.driver as $dd |
+        ([.agents[] | (.driver // $dd // "claude-code")] +
+         [(.post_process // empty | .driver // $dd // "claude-code")]) |
+        unique | length' "$CONFIG_FILE" 2>/dev/null || echo 1)
     [ "$_nd" -gt 1 ] && HAS_MULTI_DRIVERS=true
 fi
 
@@ -348,8 +350,11 @@ draw() {
         if [ -n "$_new_cfg" ] && [ "$_new_cfg" != "$CONFIG_FILE" ] && [ -f "$_new_cfg" ]; then
             CONFIG_FILE="$_new_cfg"
             local _nd
-            _nd=$(jq -r '.driver as $dd | [.agents[] | (.driver // $dd // "claude-code")] | unique | length' \
-                "$CONFIG_FILE" 2>/dev/null || echo 1)
+            _nd=$(jq -r '.driver as $dd |
+                ([.agents[] | (.driver // $dd // "claude-code")] +
+                 [(.post_process // empty |
+                   .driver // $dd // "claude-code")]) |
+                unique | length' "$CONFIG_FILE" 2>/dev/null || echo 1)
             HAS_MULTI_DRIVERS=false
             [ "$_nd" -gt 1 ] && HAS_MULTI_DRIVERS=true
 
@@ -487,7 +492,10 @@ draw() {
             "$(format_duration_ms "$a_dur")" "$agent_tag"
     done
 
-    # Post-process row (if container exists).
+    # Post-process row. If the container exists, use live Docker
+    # state; otherwise show configured post-processing before it
+    # starts so operators can distinguish "not started" from
+    # "not configured".
     local pp_name="${IMAGE_NAME}-post"
     local pp_state
     pp_state=$(docker inspect -f '{{.State.Status}}' "$pp_name" 2>/dev/null || true)
@@ -538,6 +546,31 @@ draw() {
             "$(format_tokens "$pp_cache")" \
             "$pp_turns" "$(format_tps "$pp_out" "$pp_api_ms")" \
             "$(format_duration_ms "$pp_dur")" "$pp_tag"
+    elif [ -n "$CONFIG_FILE" ] && [ -f "$CONFIG_FILE" ]; then
+        local pp_prompt
+        pp_prompt=$(jq -r '.post_process.prompt // empty' \
+            "$CONFIG_FILE" 2>/dev/null || true)
+        if [ -n "$pp_prompt" ]; then
+            local pp_model pp_effort pp_auth_mode pp_tag pp_driver
+            pp_model=$(jq -r '.post_process.model // "claude-opus-4-6"' \
+                "$CONFIG_FILE" 2>/dev/null || echo "claude-opus-4-6")
+            pp_effort=$(jq -r '.post_process.effort // empty' \
+                "$CONFIG_FILE" 2>/dev/null || true)
+            pp_auth_mode=$(jq -r '.post_process.auth // empty' \
+                "$CONFIG_FILE" 2>/dev/null || true)
+            pp_tag=$(jq -r '.post_process.tag // .tag // empty' \
+                "$CONFIG_FILE" 2>/dev/null || true)
+            pp_driver=$(jq -r '.post_process.driver // .driver // "claude-code"' \
+                "$CONFIG_FILE" 2>/dev/null || echo "claude-code")
+
+            local pp_rule
+            pp_rule=$(printf '%.0s·' $(seq 1 $((TERM_COLS - 4))))
+            printf "  ${DIM}%s${RESET}\n" "$pp_rule"
+            emit_row "PP" "$(format_model "$pp_model" "$pp_effort")" \
+                "$(short_driver "$pp_driver")" "$pp_auth_mode" \
+                "$DIM" "configured" \
+                "" "" "" "" "" "" "$pp_tag"
+        fi
     fi
 
     # Totals row.

--- a/harvest.sh
+++ b/harvest.sh
@@ -7,9 +7,11 @@ set -euo pipefail
 SWARM_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SWARM_DIR/lib/check-deps.sh"
 check_deps git
+# shellcheck source=lib/project.sh
+source "$SWARM_DIR/lib/project.sh"
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-PROJECT="$(basename "$REPO_ROOT")"
+PROJECT="$(swarm_project_id "$(basename "$REPO_ROOT")")"
 BARE_REPO="/tmp/${PROJECT}-upstream.git"
 REMOTE_NAME="_agent-harvest"
 DRY_RUN=false

--- a/launch.sh
+++ b/launch.sh
@@ -37,12 +37,15 @@ fi
 
 source "$SWARM_DIR/lib/check-deps.sh"
 check_deps git jq docker
+# shellcheck source=lib/project.sh
+source "$SWARM_DIR/lib/project.sh"
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-PROJECT="$(basename "$REPO_ROOT")"
+PROJECT_RAW="$(basename "$REPO_ROOT")"
+PROJECT="$(swarm_project_id "$PROJECT_RAW")"
 SWARM_RUN_HASH="$(git -C "$REPO_ROOT" rev-parse --short=7 HEAD 2>/dev/null || echo "unknown")"
 SWARM_RUN_BRANCH="$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")"
-SWARM_RUN_CONTEXT="${PROJECT}@${SWARM_RUN_HASH} (${SWARM_RUN_BRANCH})"
+SWARM_RUN_CONTEXT="${PROJECT_RAW}@${SWARM_RUN_HASH} (${SWARM_RUN_BRANCH})"
 BARE_REPO="/tmp/${PROJECT}-upstream.git"
 IMAGE_NAME="${PROJECT}-agent"
 

--- a/launch.sh
+++ b/launch.sh
@@ -18,9 +18,11 @@ Commands:
   stop                 Stop all running agent containers.
   logs N               Tail logs for agent N (default: 1).
   status               Show running/stopped state for each agent.
-  wait                 Block until all agents exit, then harvest
-                       (runs post-process first if configured).
-  post-process         Run the post-processing agent from the config.
+  wait                 Wait for already-started numbered agents,
+                       then post-process and harvest. Does not
+                       start agents.
+  post-process         Run only the post-processing agent, then
+                       harvest.
 
 Start options:
   --dashboard          Open the TUI dashboard after launch.

--- a/lib/project.sh
+++ b/lib/project.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Shared project-name derivation for Docker, container, and /tmp paths.
+# User-facing labels should keep the raw repository basename; internal
+# Docker identifiers must be lowercase and separator-safe.
+
+swarm_project_id() {
+    local raw="${1:-}" lower out="" c last_sep=false i
+    lower="$(printf '%s' "$raw" | LC_ALL=C tr '[:upper:]' '[:lower:]')"
+
+    for ((i = 0; i < ${#lower}; i++)); do
+        c="${lower:i:1}"
+        case "$c" in
+            [a-z0-9])
+                out+="$c"
+                last_sep=false
+                ;;
+            .|_|-)
+                if [ -n "$out" ] && [ "$last_sep" = false ]; then
+                    out+="$c"
+                    last_sep=true
+                fi
+                ;;
+            *)
+                if [ -n "$out" ] && [ "$last_sep" = false ]; then
+                    out+="-"
+                    last_sep=true
+                fi
+                ;;
+        esac
+    done
+
+    while [ -n "$out" ]; do
+        case "${out: -1}" in
+            [a-z0-9]) break ;;
+            *) out="${out%?}" ;;
+        esac
+    done
+
+    printf '%s' "${out:-swarm}"
+}

--- a/progress.sh
+++ b/progress.sh
@@ -17,9 +17,11 @@ fi
 SWARM_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SWARM_DIR/lib/check-deps.sh"
 check_deps git docker
+# shellcheck source=lib/project.sh
+source "$SWARM_DIR/lib/project.sh"
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-PROJECT="$(basename "$REPO_ROOT")"
+PROJECT="$(swarm_project_id "$(basename "$REPO_ROOT")")"
 BARE_REPO="/tmp/${PROJECT}-upstream.git"
 CHECK_DIR="/tmp/${PROJECT}-progress-check"
 

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -19,8 +19,10 @@ set -euo pipefail
 
 TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
 SWARM_DIR="$(cd "$TESTS_DIR/.." && pwd)"
+# shellcheck source=../lib/project.sh
+source "$SWARM_DIR/lib/project.sh"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-PROJECT="$(basename "$REPO_ROOT")"
+PROJECT="$(swarm_project_id "$(basename "$REPO_ROOT")")"
 BARE_REPO="/tmp/${PROJECT}-upstream.git"
 REVIEW_DIR="/tmp/${PROJECT}-test-review"
 INJECT_DIR="/tmp/${PROJECT}-test-inject"

--- a/tests/test_dashboard.sh
+++ b/tests/test_dashboard.sh
@@ -92,6 +92,7 @@ short_driver() {
     case "${1:-}" in
         claude-code) printf 'claude' ;;
         gemini-cli)  printf 'gemini' ;;
+        codex-cli)   printf 'codex'  ;;
         *)           printf '%s' "${1:-}" ;;
     esac
 }
@@ -230,6 +231,7 @@ echo "=== 4. short_driver ==="
 
 assert_eq "claude-code → claude" "claude" "$(short_driver claude-code)"
 assert_eq "gemini-cli → gemini"  "gemini" "$(short_driver gemini-cli)"
+assert_eq "codex-cli → codex"    "codex"  "$(short_driver codex-cli)"
 assert_eq "fake passthrough"     "fake"   "$(short_driver fake)"
 assert_eq "unknown passthrough"  "foo"    "$(short_driver foo)"
 assert_eq "empty → empty"       ""        "$(short_driver "")"
@@ -357,6 +359,77 @@ assert_eq "pp model widens column" "23" "$(compute_model_col_w "$TMPDIR/pp_wider
 
 # ============================================================
 echo ""
+echo "=== 7b. Pending post-process row from config ==="
+
+pending_pp_fields() {
+    jq -r '[
+        .post_process.prompt // "",
+        .post_process.model // "claude-opus-4-6",
+        .post_process.effort // "",
+        .post_process.driver // .driver // "claude-code",
+        .post_process.auth // "",
+        .post_process.tag // .tag // ""
+    ] | join("|")' "$1"
+}
+
+cat > "$TMPDIR/pp_pending.json" <<'EOF'
+{
+  "prompt": "p.md",
+  "driver": "codex-cli",
+  "tag": "scan",
+  "agents": [{ "count": 1, "model": "gpt-4o" }],
+  "post_process": {
+    "prompt": "review.md",
+    "model": "gemini-2.5-pro",
+    "effort": "high",
+    "driver": "gemini-cli",
+    "auth": "oauth",
+    "tag": "triage"
+  }
+}
+EOF
+
+IFS='|' read -r pp_prompt pp_model pp_effort pp_driver pp_auth pp_tag \
+    <<< "$(pending_pp_fields "$TMPDIR/pp_pending.json")"
+assert_eq "pp pending configured by prompt" "review.md" "$pp_prompt"
+assert_eq "pp pending model" "gemini-2.5-pro" "$pp_model"
+assert_eq "pp pending effort" "high" "$pp_effort"
+assert_eq "pp pending driver" "gemini-cli" "$pp_driver"
+assert_eq "pp pending auth" "oauth" "$pp_auth"
+assert_eq "pp pending tag" "triage" "$pp_tag"
+
+cat > "$TMPDIR/pp_pending_defaults.json" <<'EOF'
+{
+  "prompt": "p.md",
+  "driver": "codex-cli",
+  "tag": "scan",
+  "agents": [{ "count": 1, "model": "gpt-4o" }],
+  "post_process": { "prompt": "review.md" }
+}
+EOF
+
+IFS='|' read -r _ pp_model pp_effort pp_driver pp_auth pp_tag \
+    <<< "$(pending_pp_fields "$TMPDIR/pp_pending_defaults.json")"
+assert_eq "pp pending default model" "claude-opus-4-6" "$pp_model"
+assert_eq "pp pending empty effort" "" "$pp_effort"
+assert_eq "pp pending inherits driver" "codex-cli" "$pp_driver"
+assert_eq "pp pending empty auth" "" "$pp_auth"
+assert_eq "pp pending inherits tag" "scan" "$pp_tag"
+
+SHOW_INOUT=false; SHOW_AUTH=true; SHOW_TURNS=false; SHOW_TPS=false
+SHOW_CACHE=false; SHOW_TAG=true; SHOW_DRIVER=true
+pending_line=$(emit_row "PP" "$(format_model "$pp_model" "$pp_effort")" \
+    "$(short_driver "$pp_driver")" "$pp_auth" "" "configured" \
+    "" "" "" "" "" "" "$pp_tag")
+assert_eq "pending row has PP id" "true" \
+    "$(echo "$pending_line" | grep -q '^  PP' && echo true || echo false)"
+assert_eq "pending row says configured" "true" \
+    "$(echo "$pending_line" | grep -q 'configured' && echo true || echo false)"
+assert_eq "pending row uses inherited tag" "true" \
+    "$(echo "$pending_line" | grep -q 'scan' && echo true || echo false)"
+
+# ============================================================
+echo ""
 echo "=== 8. Model label fits within column ==="
 
 # Verify that common model labels don't overflow MODEL_COL_W=25.
@@ -395,8 +468,10 @@ echo ""
 echo "=== 10. HAS_MULTI_DRIVERS jq detection ==="
 
 detect_multi_drivers() {
-    jq -r '.driver as $dd | [.agents[] | (.driver // $dd // "claude-code")] | unique | length' \
-        "$1" 2>/dev/null || echo 1
+    jq -r '.driver as $dd |
+        ([.agents[] | (.driver // $dd // "claude-code")] +
+         [(.post_process // empty | .driver // $dd // "claude-code")]) |
+        unique | length' "$1" 2>/dev/null || echo 1
 }
 
 cat > "$TMPDIR/single_claude.json" <<'EOF'
@@ -455,6 +530,22 @@ cat > "$TMPDIR/all_gemini_explicit.json" <<'EOF'
 }
 EOF
 assert_eq "all gemini explicit → 1 driver" "1" "$(detect_multi_drivers "$TMPDIR/all_gemini_explicit.json")"
+
+cat > "$TMPDIR/pp_driver_split.json" <<'EOF'
+{
+  "prompt": "p.md",
+  "driver": "codex-cli",
+  "agents": [
+    { "count": 1, "model": "gpt-5" }
+  ],
+  "post_process": {
+    "prompt": "review.md",
+    "driver": "claude-code"
+  }
+}
+EOF
+assert_eq "post-process driver split → 2 drivers" "2" \
+    "$(detect_multi_drivers "$TMPDIR/pp_driver_split.json")"
 
 # ============================================================
 echo ""

--- a/tests/test_dashboard.sh
+++ b/tests/test_dashboard.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 
 PASS=0
 FAIL=0
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 assert_eq() {
     local label="$1" expected="$2" actual="$3"
@@ -578,6 +579,50 @@ USER_TITLE_T=""
 assert_eq "state title wins" "state-set" "${USER_TITLE_T:-${SWARM_TITLE_T:-${DEFAULT_TITLE_TEST}}}"
 SWARM_TITLE_T=""
 assert_eq "default title wins" "$DEFAULT_TITLE_TEST" "${USER_TITLE_T:-${SWARM_TITLE_T:-${DEFAULT_TITLE_TEST}}}"
+
+# ============================================================
+echo ""
+echo "=== 12. Post-process dashboard shortcuts ==="
+
+DASHBOARD_FILE="$TESTS_DIR/../dashboard.sh"
+
+assert_eq "help documents lowercase pp logs" "1" \
+    "$(grep -cF 'p           Tail post-process logs' "$DASHBOARD_FILE")"
+assert_eq "help documents uppercase pp start" "1" \
+    "$(grep -cF 'P           Start the post-processing agent' \
+        "$DASHBOARD_FILE")"
+assert_eq "p and P are not the same case arm" "0" \
+    "$(grep -cF 'p|P)' "$DASHBOARD_FILE" || true)"
+
+pp_lower_case=$(awk '
+    /^[[:space:]]*p\)/ { p = 1 }
+    p { print }
+    p && /^                ;;/ { exit }
+' "$DASHBOARD_FILE")
+pp_upper_case=$(awk '
+    /^[[:space:]]*P\)/ { p = 1 }
+    p { print }
+    p && /^                ;;/ { exit }
+' "$DASHBOARD_FILE")
+
+assert_eq "lowercase p follows pp logs" "1" \
+    "$(printf '%s\n' "$pp_lower_case" \
+        | grep -cF 'docker logs -f "$_pp_name"' || true)"
+assert_eq "lowercase p points to uppercase start" "1" \
+    "$(printf '%s\n' "$pp_lower_case" \
+        | grep -cF 'press P to start' || true)"
+assert_eq "lowercase p does not start post-process" "0" \
+    "$(printf '%s\n' "$pp_lower_case" \
+        | grep -cF '"$SWARM_DIR/launch.sh" post-process' || true)"
+assert_eq "uppercase P asks for confirmation" "true" \
+    "$([ "$(printf '%s\n' "$pp_upper_case" \
+        | grep -cF '[y/N]' || true)" -gt 0 ] && echo true || echo false)"
+assert_eq "uppercase P can launch post-process" "1" \
+    "$(printf '%s\n' "$pp_upper_case" \
+        | grep -cF '"$SWARM_DIR/launch.sh" post-process' || true)"
+assert_eq "uppercase P has cancellation path" "1" \
+    "$(printf '%s\n' "$pp_upper_case" \
+        | grep -cF 'post-processing not started' || true)"
 
 # ============================================================
 echo ""

--- a/tests/test_launch.sh
+++ b/tests/test_launch.sh
@@ -658,6 +658,12 @@ done
 out=$(PATH="$FAKE_BIN" bash "$TESTS_DIR/../launch.sh" --help 2>&1) \
     && rc=0 || rc=$?
 assert_eq "launch --help exits 0 without jq" "0" "$rc"
+assert_eq "launch help says wait does not start agents" "true" \
+    "$([[ "$out" == *"Does not"* && "$out" == *"start agents"* ]] \
+        && echo true || echo false)"
+assert_eq "launch help says post-process harvests" "true" \
+    "$([[ "$out" == *"Run only the post-processing agent"* \
+        && "$out" == *"harvest"* ]] && echo true || echo false)"
 
 # dashboard.sh --help should exit 0 even without jq/docker/tput/bc.
 out=$(PATH="$FAKE_BIN" bash "$TESTS_DIR/../dashboard.sh" --help 2>&1) \

--- a/tests/test_launch.sh
+++ b/tests/test_launch.sh
@@ -16,6 +16,8 @@ FAIL=0
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=../lib/project.sh
+source "$TESTS_DIR/../lib/project.sh"
 
 assert_eq() {
     local label="$1" expected="$2" actual="$3"
@@ -116,6 +118,20 @@ build_oauth_extra_env() {
         && EXTRA_ENV+=(-e "CLAUDE_CODE_OAUTH_TOKEN=${token}")
     echo "${EXTRA_ENV[*]+"${EXTRA_ENV[*]}"}"
 }
+
+# ============================================================
+echo "=== 0. Project ID sanitization ==="
+
+assert_eq "lowercase project unchanged" \
+    "claude-swarm" "$(swarm_project_id "claude-swarm")"
+assert_eq "uppercase project lowercased" \
+    "leanmultisig-swarm" "$(swarm_project_id "leanMultisig-swarm")"
+assert_eq "spaces collapse to separator" \
+    "my-repo" "$(swarm_project_id "My Repo!")"
+assert_eq "leading/trailing separators trimmed" \
+    "repo" "$(swarm_project_id "_Repo.")"
+assert_eq "empty/all separators fallback" \
+    "swarm" "$(swarm_project_id "---")"
 
 # ============================================================
 echo "=== 1. Model name shortening ==="


### PR DESCRIPTION
## Summary
  - Sanitize Docker/project identifiers derived from repo basenames so uppercase paths work.
  - Show configured post-processing in the dashboard before the `PP` container starts.
  - Add a dedicated post-process log shortcut and require confirmation before starting post-process.
  - Clarify that `launch.sh wait` waits for already-started agents and does not launch them.

  ## Changes
  - `lib/project.sh`, `launch.sh`, `dashboard.sh`, `harvest.sh`, `costs.sh`, `progress.sh`, `tests/test.sh`: share a Docker-safe internal project id while preserving raw repo names for display/run context.
  - `dashboard.sh`, `tests/test_dashboard.sh`: render pending `PP` rows, add `p` for post-process logs, and use confirmed `P` for starting/replacing post-process.
  - `README.md`, `USAGE.md`, `launch.sh`, `tests/test_launch.sh`: document the `start` then `wait` flow and manual post-process/harvest behavior.
  - `CHANGELOG.md`: add unreleased entries for the fixes.

  ## Test plan
  - [x] `./tests/test_dashboard.sh`
  - [x] `./tests/test_launch.sh`
  - [x] `./tests/test.sh --all`