### PR TITLE
Propagate post-process container exit code

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -928,9 +928,22 @@ cmd_post_process() {
         break
     done
 
+    # Capture container exit code BEFORE harvest. Harvest runs unconditionally
+    # so a crashed agent's in-flight commits still land locally (best-effort
+    # recovery), but we propagate the failure upward so callers (CI workflows,
+    # daemons) can refuse to publish partial state.
+    local exit_code
+    exit_code=$(docker inspect -f '{{.State.ExitCode}}' "$NAME" 2>/dev/null || echo "1")
+
     echo ""
     echo "--- Harvesting results ---"
     "$SWARM_DIR/harvest.sh"
+
+    if [ "$exit_code" -ne 0 ]; then
+        echo "WARNING: post-process container exited with code ${exit_code};" \
+             "any commits harvested may represent partial state." >&2
+        return "$exit_code"
+    fi
 }
 
 case "${1:-start}" in

--- a/tests/test_launch.sh
+++ b/tests/test_launch.sh
@@ -1887,6 +1887,31 @@ assert_eq "Dockerfile copies interactive entrypoint" "1" \
 
 # ============================================================
 echo ""
+echo "=== 42. cmd_post_process propagates container exit code ==="
+
+# Partial-output recovery contract: when the post-process container
+# crashes after committing some findings into the bare repo, harvest
+# still runs (so the work isn't lost on the local branch) but the
+# function returns the container's exit code.  CI workflows / daemons
+# gate publish on this signal so partial state doesn't ship.
+_pp_body=$(awk '
+    /^cmd_post_process\(\)[[:space:]]*\{/ { p = 1 }
+    p { print }
+    p && /^\}[[:space:]]*$/ { exit }
+' "$_LAUNCH_SH")
+
+assert_eq "cmd_post_process captures State.ExitCode" "1" \
+    "$(printf '%s\n' "$_pp_body" \
+        | grep -cE 'docker inspect[[:space:]]+-f[[:space:]]+.*State\.ExitCode' \
+        || true)"
+
+assert_eq "cmd_post_process returns container exit code on failure" "1" \
+    "$(printf '%s\n' "$_pp_body" \
+        | grep -cE 'return[[:space:]]+"\$exit_code"' \
+        || true)"
+
+# ============================================================
+echo ""
 echo "==============================="
 echo "  ${PASS} passed, ${FAIL} failed"
 echo "==============================="


### PR DESCRIPTION
## Summary

- `cmd_post_process` now propagates the post-process container's exit code instead of always returning success.
- Harvest still runs unconditionally, so a crashed agent's in-flight commits are still recovered onto the local branch (best-effort).
- On a non-zero exit, it warns that harvested commits may be partial state and returns the container's code.
- Gives callers (CI workflows, daemons) a real signal to gate publish on, so partial state doesn't ship.

## Changes

- `launch.sh`: In `cmd_post_process`, capture `docker inspect -f '{{.State.ExitCode}}' "$NAME"` *before* harvest (falling back to `1` if inspect fails). Harvest still runs unconditionally; afterward, if the code is non-zero, log a warning to stderr and `return "$exit_code"`. Previously the function swallowed the failure and returned success.
- `tests/test_launch.sh`: Add section "42. cmd_post_process propagates container exit code", asserting the function captures `State.ExitCode` and returns `$exit_code` on failure. Documents the partial-output recovery contract (harvest runs, but the failure propagates).

## Self-review checklist

- [x] This PR addresses a **single concern** ([why?](https://blog.ploeh.dk/2015/01/15/10-tips-for-better-pull-requests/#2-do-only-one-thing)). If it covers multiple independent changes, I've split them into separate PRs.

## Test plan

- [x] `./tests/test.sh --unit` — 1357 tests pass, 0 failed (`test_launch.sh`: 223).
- [ ] `./tests/test.sh --all` — full integration matrix (Docker + API key); run in CI.
- Behavior: a post-process container exiting non-zero causes `cmd_post_process` to harvest, warn on stderr, then return that exit code; a clean exit returns 0 as before.
